### PR TITLE
(GH-27) fix creation path of 'item' templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 .DS_Store
 
 pdk
+pct

--- a/cmd/new/new.go
+++ b/cmd/new/new.go
@@ -1,7 +1,6 @@
 package new
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -40,9 +39,8 @@ func CreateCommand() *cobra.Command {
 
 	tmp.Flags().SortFlags = false
 
-	cwd, _ := os.Getwd()
-	tmp.Flags().StringVarP(&targetName, "name", "n", filepath.Base(cwd), "the name for the created output.")
-	tmp.Flags().StringVarP(&targetOutput, "output", "o", cwd, "location to place the generated output.")
+	tmp.Flags().StringVarP(&targetName, "name", "n", "", "the name for the created output.")
+	tmp.Flags().StringVarP(&targetOutput, "output", "o", "", "location to place the generated output.")
 
 	tmp.Flags().BoolVarP(&listTemplates, "list", "l", false, "list templates")
 	tmp.RegisterFlagCompletionFunc("list", flagCompletion) //nolint:errcheck


### PR DESCRIPTION
This commit fixes an issue whereby `item` templates would be added to the parent directory rather than the current working directory (CWD).

By default `pct new` will add content from templates in the CWD.  The behaviour can be overridden by supplying the `--output` flag