### PR TITLE
(maint) Align build scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '*.*.*'
 
 env:
   go_version: 1.16

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 project_name: pdk
 
 release:
-  name_template: "PDK {{.Version}}"
+  name_template: "PCT {{.Version}}"
+  prerelease: auto
 
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: pdk
+project_name: pct
 
 release:
   name_template: "PCT {{.Version}}"
@@ -29,7 +29,8 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 archives:
-  - replacements:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ tolower .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
@@ -44,7 +45,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ .Tag }}-{{.ShortCommit}}"
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
-    wrap_in_directory: true
+    wrap_in_directory: false
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,9 +8,7 @@ before:
     - go mod tidy
 
 builds:
-  - main: main.go
-    binary: pct
-    mod_timestamp: '{{ .CommitTimestamp }}'
+  - binary: pct
     env:
       - CGO_ENABLED=0
     goos:
@@ -21,8 +19,13 @@ builds:
       - amd64
       - arm
       - arm64
+    asmflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    gcflags:
+      - all=-trimpath={{.Env.GOPATH}}
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.CommitDate}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
 
 archives:
   - replacements:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,23 +22,25 @@ Prerequisites:
 
 To build the PDK, run the following command:
 
+> These build scripts produce a binary for the current platform only. These scripts are meant for local testing. We use a Github Action to release this product.
+
 ```bash
 > # on nix
-> go build -o pdk
+> ./build.sh
 ```
 
 ```powershell
 # on windows
-> go build -o pdk.exe
+> ./build.ps1
 ```
 
 To run the new binary:
 
 ```bash
-> ./pdk
+> ./pct [command]
 ```
 
-To test the PDK, run the following command.
+To test the PCT command, run the following command.
 
 ```bash
 > go test ./...
@@ -47,8 +49,7 @@ To test the PDK, run the following command.
 ## Running the project
 
 ```bash
-> # on nix
-> go run cmd/pdk/main.go
+> go run main.go
 ```
 
 ## Building Cross Platform binaries
@@ -58,7 +59,7 @@ Prerequisites:
 - Go 1.16+
 - goreleaser 0.16+
 
-To build the PDK for more than your current platform, use [`GoReleaser`](https://goreleaser.com/quick-start/#dry-run):
+To build the PCT for more than your current platform, use [`GoReleaser`](https://goreleaser.com/quick-start/#dry-run):
 
 ```bash
 > goreleaser --snapshot --skip-publish --rm-dist

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,4 @@
 #!/usr/bin/env pwsh
 
-go build -v -o pct.exe
+# Set goreleaser to build for current platform only
+goreleaser build --snapshot --rm-dist --single-target

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-go build -v -o pct
+# Set goreleaser to build for current platform only
+goreleaser build --snapshot --rm-dist --single-target


### PR DESCRIPTION
Update build scripts to call the goreleaser build to ensure a consistent binary is produced locally.

Update the goreleaser script to produce a production ready binary and set the Github release info.