### PR TITLE
(GH-29) Error if template not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (GH-2) Created Puppet Content Templates package and modified pdk new to use PCT
 - (GH-7) Added wrapper to all existing PDK commands
+
+### Fixed
+
+- (GH-29) Error if template not found

--- a/cmd/new/new.go
+++ b/cmd/new/new.go
@@ -133,6 +133,11 @@ func execute(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	_, err := pct.Get(localTemplateCache, selectedTemplate)
+	if err != nil {
+		return err
+	}
+
 	appVersionString := cmd.Parent().Version
 	pdkInfo := getApplicationInfo(appVersionString)
 
@@ -144,7 +149,7 @@ func execute(cmd *cobra.Command, args []string) error {
 		PdkInfo:          pdkInfo,
 	})
 
-	err := pct.FormatDeployment(deployed, format)
+	err = pct.FormatDeployment(deployed, format)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -74,6 +74,16 @@ type DeployInfo struct {
 	PdkInfo          PDKInfo
 }
 
+func Get(templateCache string, selectedTemplate string) (PuppetContentTemplate, error) {
+	file := filepath.Join(templateCache, selectedTemplate, TemplateConfigFileName)
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return PuppetContentTemplate{}, fmt.Errorf("Couldn't find an installed template that matches '%s'", selectedTemplate)
+	}
+	i := readTemplateConfig(file)
+	return i, nil
+}
+
 // List lists all templates in a given path and parses their configuration. Does
 // not return any errors from parsing invalid templates, but returns them as
 // debug log events

--- a/internal/pkg/pct/pct_test.go
+++ b/internal/pkg/pct/pct_test.go
@@ -69,6 +69,52 @@ func TestDeploy(t *testing.T) {
 	}
 }
 
+func TestGet(t *testing.T) {
+	type args struct {
+		templateCache    string
+		selectedTemplate string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    PuppetContentTemplate
+		wantErr bool
+	}{
+		{
+			name:    "returns error for non-existent template",
+			args:    args{},
+			wantErr: true,
+		},
+		{
+			name: "returns tmpl for existent template",
+			args: args{
+				templateCache:    "testdata/examples",
+				selectedTemplate: "full-project",
+			},
+			want: PuppetContentTemplate{
+				Id:      "full-project",
+				Type:    "project",
+				Display: "Full Project",
+				Version: "0.1.0",
+				URL:     "https://github.com/puppetlabs/pct-full-project",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Get(tt.args.templateCache, tt.args.selectedTemplate)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_createTemplateFile(t *testing.T) {
 	type args struct {
 		targetName   string


### PR DESCRIPTION
Add a new func to the `pct` pacakge to retrieve a PCT from the local filesystem. Modify `pct new` to return a formatted error if the PCT is not found.
