### PR TITLE
(GH-20) Bundle pct-templates with pkg

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,11 +8,11 @@ env:
   go_version: 1.16
 
 jobs:
-  build:
+  build_unix:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       GOPATH: ${{ github.workspace }}
@@ -24,16 +24,36 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.go_version }}
-
     - name: Build
       run: |
-          go get github.com/goreleaser/goreleaser
-          goreleaser build --snapshot --rm-dist --single-target
-
+        go get github.com/goreleaser/goreleaser
+        ./build.sh
     - name: Test
-      run: go test -v github.com/puppetlabs/pdkgo/acceptance
+      run: go test -v ./acceptance
+  build_win:
+    runs-on: windows-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+      TEST_ACCEPTANCE: true
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.go_version }}
+    - name: Build
+      shell: pwsh
+      run: |
+        go get github.com/goreleaser/goreleaser
+        .\build.ps1
+    - name: Test
+      run: go test -v ./acceptance

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,11 +8,11 @@ env:
   go_version: 1.16
 
 jobs:
-  build_unix:
+  build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       GOPATH: ${{ github.workspace }}
@@ -28,32 +28,15 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.go_version }}
-    - name: Build
+    - name: Build nix
       run: |
         go get github.com/goreleaser/goreleaser
         ./build.sh
-    - name: Test
-      run: go test -v ./acceptance
-  build_win:
-    runs-on: windows-latest
-    env:
-      GOPATH: ${{ github.workspace }}
-      TEST_ACCEPTANCE: true
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ env.go_version }}
-    - name: Build
-      shell: pwsh
+      if: runner.os != 'Windows'
+    - name: Build Windows
       run: |
         go get github.com/goreleaser/goreleaser
-        .\build.ps1
+        ./build.ps1
+      if: runner.os == 'Windows'
     - name: Test
       run: go test -v ./acceptance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
+        name: Checkout pdkgo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      -
+        name: Checkout PCT Templates
+        uses: actions/checkout@v2
+        with:
+          repository: puppetlabs/baker-round
+          fetch-depth: 0
+          path: templates
       -
         name: Set up Go
         uses: actions/setup-go@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - templates/**/*
 
 checksum:
   name_template: 'checksums.txt'

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,23 @@
 #!/usr/bin/env pwsh
 
-# Set goreleaser to build for current platform only
-goreleaser build --snapshot --rm-dist --single-target
+[CmdletBinding()]
+param (
+  [Parameter()]
+  [ValidateSet('build', 'package')]
+  [string]
+  $Target = 'build'
+)
+switch ($Target) {
+  'build' {
+    $arch = go env GOHOSTARCH
+    $platform = go env GOHOSTOS
+    $binPath = Join-Path $PSScriptRoot "dist" "pct_${platform}_${arch}"
+    # Set goreleaser to build for current platform only
+    goreleaser build --snapshot --rm-dist --single-target
+    git clone -b main --single-branch https://github.com/puppetlabs/baker-round (Join-Path $binPath "templates")
+  }
+  'package' {
+    git clone -b main --single-branch https://github.com/puppetlabs/baker-round "templates"
+    goreleaser --skip-publish --snapshot --rm-dist
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 
-# Set goreleaser to build for current platform only
-goreleaser build --snapshot --rm-dist --single-target
+target=${1:-build}
+if [ "$target" == "build" ]; then
+  arch=$(go env GOHOSTARCH)
+  platform=$(go env GOHOSTOS)
+  binPath="$(pwd)/dist/pct_${platform}_${arch}"
+  # Set goreleaser to build for current platform only
+  goreleaser build --snapshot --rm-dist --single-target
+  git clone -b main --single-branch https://github.com/puppetlabs/baker-round "$binPath/templates"
+elif [ "$target" == "package" ]; then
+  git clone -b main --single-branch https://github.com/puppetlabs/baker-round "templates"
+  goreleaser --skip-publish --snapshot --rm-dist
+fi

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -100,7 +100,9 @@ func Get(templateCache string, selectedTemplate string) (PuppetContentTemplate, 
 // not return any errors from parsing invalid templates, but returns them as
 // debug log events
 func List(templatePath string, templateName string) ([]PuppetContentTemplate, error) {
+	log.Debug().Msgf("Searching %+v for templates", templatePath)
 	matches, _ := filepath.Glob(templatePath + "/**/" + TemplateConfigFileName)
+
 	var tmpls []PuppetContentTemplate
 	for _, file := range matches {
 		log.Debug().Msgf("Found: %+v", file)
@@ -122,7 +124,11 @@ func FormatTemplates(tmpls []PuppetContentTemplate, jsonOutput string) error {
 	switch jsonOutput {
 	case "table":
 		fmt.Println("")
-		if len(tmpls) == 1 {
+
+		count := len(tmpls)
+		if count < 1 {
+			log.Warn().Msgf("Could not locate any templates at %+v", viper.GetString("templatepath"))
+		} else if count == 1 {
 			fmt.Printf("DisplayName:     %v\n", tmpls[0].Display)
 			fmt.Printf("Name:            %v\n", tmpls[0].Id)
 			fmt.Printf("TemplateType:    %v\n", tmpls[0].Type)


### PR DESCRIPTION
This commit modifies `new.go` to set the default template path to
be the `$INSTALL_ROOT/templates` directory, enabling a "ready to go"
experience for the PCT LA. When a user runs `pct new --list` they
will see the default templates we have elected to ship with the package.

Also added a warning log message in the `pct#Get` function to alert
the user if no templates could be found.

The build scripts can now create a build for local development
purposes or a production ready snapshot using the arguments, "build"
or "snapshot", respectively. The scripts will also handle fetching
the default content templates from `puppetlabs/baker-round`.