### PR TITLE
(GH-20) Set default 'templatepath' to "$INSTALL_ROOT/templates"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
+        name: Checkout pdkgo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      -
+        name: Checkout PCT Templates
+        uses: actions/checkout@v2
+        with:
+          repository: puppetlabs/baker-round
+          fetch-depth: 0
+          path: templates
       -
         name: Set up Go
         uses: actions/setup-go@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - templates/**/*
 
 checksum:
   name_template: 'checksums.txt'

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,23 @@
 #!/usr/bin/env pwsh
 
-# Set goreleaser to build for current platform only
-goreleaser build --snapshot --rm-dist --single-target
+[CmdletBinding()]
+param (
+  [Parameter()]
+  [ValidateSet('build', 'package')]
+  [string]
+  $Target = 'build'
+)
+switch ($Target) {
+  'build' {
+    $arch = go env GOHOSTARCH
+    $platform = go env GOHOSTOS
+    $binPath = Join-Path $PSScriptRoot "dist" "pct_${platform}_${arch}"
+    # Set goreleaser to build for current platform only
+    goreleaser build --snapshot --rm-dist --single-target
+    git clone -b main --single-branch https://github.com/puppetlabs/baker-round (Join-Path $binPath "templates")
+  }
+  'package' {
+    git clone -b main --single-branch https://github.com/puppetlabs/baker-round "templates"
+    goreleaser --skip-publish --snapshot --rm-dist
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 
-# Set goreleaser to build for current platform only
-goreleaser build --snapshot --rm-dist --single-target
+target=${1:-build}
+if [ "$target" == "build" ]; then
+  arch=$(go env GOHOSTARCH)
+  platform=$(go env GOHOSTOS)
+  binPath="$(pwd)/dist/pct_${platform}_${arch}"
+  # Set goreleaser to build for current platform only
+  goreleaser build --snapshot --rm-dist --single-target
+  git clone -b main --single-branch https://github.com/puppetlabs/baker-round "$binPath/templates"
+elif [ "$target" == "package" ]; then
+  git clone -b main --single-branch https://github.com/puppetlabs/baker-round "templates"
+  goreleaser --skip-publish --snapshot --rm-dist
+fi

--- a/cmd/new/new.go
+++ b/cmd/new/new.go
@@ -7,7 +7,6 @@ import (
 	"github.com/puppetlabs/pdkgo/internal/pkg/pct"
 	"github.com/puppetlabs/pdkgo/internal/pkg/utils"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,12 +28,8 @@ func CreateCommand() *cobra.Command {
 		Long:              `Creates a Puppet project or other artifact based on a template`,
 		Args:              validateArgCount,
 		ValidArgsFunction: flagCompletion,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			log.Trace().Msg("PreRunE")
-			localTemplateCache = viper.GetString("templatepath")
-			return nil
-		},
-		RunE: execute,
+		PreRunE:           preExecute,
+		RunE:              execute,
 	}
 
 	tmp.Flags().SortFlags = false
@@ -54,11 +49,20 @@ func CreateCommand() *cobra.Command {
 		return utils.Find(formats, toComplete), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 	})
 
-	home, _ := homedir.Dir()
 	tmp.Flags().StringVar(&localTemplateCache, "templatepath", "", "location of installed templates")
 	viper.BindPFlag("templatepath", tmp.Flags().Lookup("templatepath")) //nolint:errcheck
-	viper.SetDefault("templatepath", filepath.Join(home, ".pdk", "pct"))
 	return tmp
+}
+
+func preExecute(cmd *cobra.Command, args []string) error {
+	defaultTemplatePath, err := getDefaultTemplatePath()
+	if err != nil {
+		return err
+	}
+
+	viper.SetDefault("templatepath", defaultTemplatePath)
+	localTemplateCache = viper.GetString("templatepath")
+	return nil
 }
 
 func validateArgCount(cmd *cobra.Command, args []string) error {
@@ -153,4 +157,15 @@ func execute(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func getDefaultTemplatePath() (string, error) {
+	execDir, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	defaultTemplatePath := filepath.Join(filepath.Dir(execDir), "templates")
+	log.Trace().Msgf("Default template path: %v", defaultTemplatePath)
+	return defaultTemplatePath, nil
 }

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -100,7 +100,9 @@ func Get(templateCache string, selectedTemplate string) (PuppetContentTemplate, 
 // not return any errors from parsing invalid templates, but returns them as
 // debug log events
 func List(templatePath string, templateName string) ([]PuppetContentTemplate, error) {
+	log.Debug().Msgf("Searching %+v for templates", templatePath)
 	matches, _ := filepath.Glob(templatePath + "/**/" + TemplateConfigFileName)
+
 	var tmpls []PuppetContentTemplate
 	for _, file := range matches {
 		log.Debug().Msgf("Found: %+v", file)
@@ -122,7 +124,11 @@ func FormatTemplates(tmpls []PuppetContentTemplate, jsonOutput string) error {
 	switch jsonOutput {
 	case "table":
 		fmt.Println("")
-		if len(tmpls) == 1 {
+
+		count := len(tmpls)
+		if count < 1 {
+			log.Warn().Msgf("Could not locate any templates at %+v", viper.GetString("templatepath"))
+		} else if count == 1 {
 			fmt.Printf("DisplayName:     %v\n", tmpls[0].Display)
 			fmt.Printf("Name:            %v\n", tmpls[0].Id)
 			fmt.Printf("TemplateType:    %v\n", tmpls[0].Type)


### PR DESCRIPTION
This commit modifies `new.go` to set the default template path to
be the `$INSTALL_ROOT/templates` directory, enabling a "ready to go"
experience for the PCT LA. When a user runs `pct new --list` they
will see the default templates we have elected to ship with the package.

Also added a warning log message in the `pct#Get` function to alert
the user if no templates could be found.

The build scripts can now create a build for local development
purposes or a production ready snapshot using the arguments, "build"
or "snapshot", respectively. The scripts will also handle fetching
the default content templates from `puppetlabs/baker-round`.

<!--
Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/pdkgo/blob/main/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/pdkgo/blob/main/CODE_OF_CONDUCT.md

Submitting a Pull Request:

- Create a fork of this repo in Github
- Create a new branch `git checkout -b my-branch-name`
- Make you change, add tests, and ensure tests pass
- Do not reformat existing code, it makes it hard to see what has changed. Leave the formatting to us.
- Make sure your commit messages are in the proper format. If the commit addresses an issue filed in the project, start the first line of the commit with the prefix `GH-` and the issue number in parentheses `(GH-111)`. Then leave a detailed explanation of your change, so a person in the future can understand what your work does.
- Update the `Unreleased` section in the CHANGELOG.md with your change

THANKS!
-->
