### PR TITLE
(GH-43) Add info flag to pct new

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
The `info` flag prints out the default configuration of a template, as found in `pct-config.yml` for the desired template id.


![pct-new-info](https://user-images.githubusercontent.com/1346683/119520048-d8221b00-bd71-11eb-94b4-ff1c14aa2e3c.gif)
