### PR TITLE
(GH-67) Add installation scripts for PCT

### DIFF
--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param (
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+$org = 'puppetlabs'
+$repo = 'pdkgo'
+
+$app = 'pct'
+
+$arch = "x86_64"
+$os = 'windows'
+$ext = '.zip'
+
+$ver = (Invoke-RestMethod "https://api.github.com/repos/${org}/${repo}/releases")[0].tag_name
+$file = "${app}_${ver}_${os}_${arch}${ext}"
+$downloadURL = "https://github.com/${org}/${repo}/releases/download/$ver/$file"
+
+$Destination = "~/.puppetlabs/pct"
+$Destination = $PSCmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Destination)
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+$null = New-Item -ItemType Directory -Path $tempDir -Force -ErrorAction SilentlyContinue
+$packagePath = Join-Path -Path $tempDir -ChildPath $file
+
+if (!$PSVersionTable.ContainsKey('PSEdition') -or $PSVersionTable.PSEdition -eq "Desktop") {
+  $oldProgressPreference = $ProgressPreference
+  $ProgressPreference = "SilentlyContinue"
+}
+
+try {
+  Write-Host "Downloading and extracting ${app} ${ver} to ${Destination}"
+  Invoke-WebRequest -Uri $downloadURL -OutFile $packagePath
+}
+finally {
+  if (!$PSVersionTable.ContainsKey('PSEdition') -or $PSVersionTable.PSEdition -eq "Desktop") {
+    $ProgressPreference = $oldProgressPreference
+  }
+}
+
+if (Test-Path -Path $Destination) {
+  Remove-Item -Path $Destination -Force -Recurse
+}
+Expand-Archive -Path $packagePath -DestinationPath $Destination
+
+Write-Host 'Remember to add the pct app to your path:'
+Write-Host "`$env:Path += `"`$env:PATH;${Destination}`""

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+org="puppetlabs"
+repo="pdkgo"
+
+app="pct"
+
+arch="x86_64"
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ext=".tar.gz"
+
+releases=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${org}/${repo}/releases")
+
+ver=$(echo $releases | grep -oE -m 1 '"tag_name": "(([0-9]+\.)+[0-9]+(-pre+)?)"' | cut -d '"' -f 4)
+
+file="${app}_${ver}_${os}_${arch}${ext}"
+
+downloadURL="https://github.com/${org}/${repo}/releases/download/${ver}/${file}"
+
+destination="${HOME}/.puppetlabs/pct"
+
+[ -d ${destination} ] || mkdir -p ${destination}
+
+echo "Downloading and extracting ${app} ${ver} to ${destination}"
+curl -L -s ${downloadURL} -o - | tar xz -C ${destination}
+
+echo 'Remember to add the pct app to your path:'
+echo 'export PATH=$PATH:'${destination}


### PR DESCRIPTION
Adds an `install.[ps1|sh]` script to:
- Fetch the latest tag from the puppetlabs/pdkgo repo
- Download the latest PCT archive to `$HOME/.puppetlabs/pct`

Closes #67 