### PR TITLE
(GH-64) Strip pct from command name

### DIFF
--- a/internal/pkg/pdkshell/pdkshell.go
+++ b/internal/pkg/pdkshell/pdkshell.go
@@ -31,6 +31,7 @@ func Execute(args []string) (int, error) {
 	cmd := &exec.Cmd{
 		Path:   executable,
 		Args:   args,
+		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Env:    env,

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -71,7 +71,7 @@ func ExecutePDKCommand(cmd *cobra.Command, args []string) error {
 
 func buildPDKCommandName(cmd *cobra.Command) []string {
 	var argsV []string
-	if cmd.HasParent() && cmd.Parent().Name() != "pdk" {
+	if cmd.HasParent() && cmd.Parent().Name() != "pct" {
 		argsV = append(argsV, cmd.Parent().Name(), cmd.Name())
 	} else {
 		argsV = append(argsV, cmd.Name())


### PR DESCRIPTION
Update to replace `pdk` removal with `pct` removal

