### PR TITLE
(GH-65) Allow deployment of empty files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ templates/
 
 .DS_Store
 
-pdk
-pct
+./pdk
+./pct

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -314,13 +314,13 @@ func createTemplateFile(targetName string, configFile string, templateFile Puppe
 		pdkInfo,
 	)
 
-	text := renderFile(templateFile.TemplatePath, config)
-	if text == "" {
+	text, err := renderFile(templateFile.TemplatePath, config)
+	if err != nil {
 		return fmt.Errorf("Failed to create %s", templateFile.TargetFilePath)
 	}
 
 	log.Trace().Msgf("Writing: '%s' '%s'", templateFile.TargetFilePath, text)
-	err := os.MkdirAll(templateFile.TargetDir, os.ModePerm)
+	err = os.MkdirAll(templateFile.TargetDir, os.ModePerm)
 	if err != nil {
 		log.Error().Msgf("Error: %v", err)
 		return err
@@ -449,7 +449,7 @@ func readTemplateConfig(configFile string) PuppetContentTemplateInfo {
 	return config
 }
 
-func renderFile(fileName string, vars interface{}) string {
+func renderFile(fileName string, vars interface{}) (string, error) {
 	tmpl, err := template.
 		New(filepath.Base(fileName)).
 		Funcs(
@@ -463,10 +463,10 @@ func renderFile(fileName string, vars interface{}) string {
 
 	if err != nil {
 		log.Error().Msgf("Error parsing config: %v", err)
-		return ""
+		return "", err
 	}
 
-	return process(tmpl, vars)
+	return process(tmpl, vars), nil
 }
 
 func process(t *template.Template, vars interface{}) string {

--- a/internal/pkg/pct/pct_test.go
+++ b/internal/pkg/pct/pct_test.go
@@ -434,6 +434,7 @@ func Test_renderFile(t *testing.T) {
 		name string
 		args args
 		want string
+		err bool
 	}{
 		{
 			name: "takes a template file and returns correct text",
@@ -444,6 +445,7 @@ func Test_renderFile(t *testing.T) {
 				},
 			},
 			want: "This is wakka data",
+			err: false,
 		},
 		{
 			name: "returns nil if file does not exist",
@@ -454,11 +456,15 @@ func Test_renderFile(t *testing.T) {
 				},
 			},
 			want: "",
+			err: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := renderFile(tt.args.fileName, tt.args.vars); got != tt.want {
+			got, err := renderFile(tt.args.fileName, tt.args.vars)
+			if tt.err && err == nil {
+				t.Fail()
+			} else if !tt.err && got != tt.want {
 				t.Errorf("renderFile() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This change ensures that empty files within a content directory are deployed. Previously empty file content assumed an error had occurred.

