### PR TITLE
(GH-107) Initialize zerolog via cobra.OnInitialize method

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -21,32 +21,31 @@ var (
 	// format string
 )
 
+func InitLogger() {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+
+	lvl, err := zerolog.ParseLevel(LogLevel)
+	if err != nil {
+		panic("Could not initialize zerolog")
+	}
+
+	zerolog.SetGlobalLevel(lvl)
+
+	if lvl == zerolog.InfoLevel {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
+	} else {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout}).With().Caller().Logger()
+	}
+
+	log.Trace().Msg("Initialized zerolog")
+}
+
 func CreateRootCommand() *cobra.Command {
 	tmp := &cobra.Command{
 		Use:   "pct",
 		Short: "pdk - Puppet Development Kit",
 		Long:  `Puppet development tooling, content creation, and testing framework`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-
-			lvl, err := zerolog.ParseLevel(LogLevel)
-			if err != nil {
-				return err
-			}
-
-			zerolog.SetGlobalLevel(lvl)
-
-			if lvl == zerolog.InfoLevel {
-				log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
-			} else {
-				log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout}).With().Caller().Logger()
-			}
-
-			log.Trace().Msg("PersistentPreRunE")
-
-			return nil
 		},
 	}
 	tmp.Flags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pdk.yaml)")

--- a/main.go
+++ b/main.go
@@ -78,6 +78,6 @@ func main() {
 	rootCmd.AddCommand(bundle.CreateCommand())
 	rootCmd.AddCommand(console.CreateCommand())
 
-	cobra.OnInitialize(root.InitConfig)
+	cobra.OnInitialize(root.InitLogger, root.InitConfig)
 	cobra.CheckErr(rootCmd.Execute())
 }


### PR DESCRIPTION
Prior to this change, the trace log line from root#InitConfig
would always output, regardless of log level as zerolog was being
initialized after this point.

This change breaks out the zerolog initialisation in to it's own
method then initializes it from the cobra.OnInitialize method,
prior to any subsequent logging method calls.

Closes: #107 