### PR TITLE
(GH-125) Fix `$ver` bug in download script

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 org="puppetlabs"
 repo="pdkgo"
@@ -9,9 +10,9 @@ arch="x86_64"
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ext=".tar.gz"
 
-releases=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${org}/${repo}/releases")
+releases="$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${org}/${repo}/releases")"
 
-ver=$(echo $releases | grep -oE -m 1 '"tag_name": "(([0-9]+\.)+[0-9]+(-pre+)?)"' | cut -d '"' -f 4 | head -1)
+ver="$(echo "$releases" | grep -oE -m 1 '"tag_name": "(([0-9]+\.)+[0-9]+(-pre+)?)"' | cut -d '"' -f 4 | head -1)"
 
 file="${app}_${ver}_${os}_${arch}${ext}"
 
@@ -19,10 +20,10 @@ downloadURL="https://github.com/${org}/${repo}/releases/download/${ver}/${file}"
 
 destination="${HOME}/.puppetlabs/pct"
 
-[ -d ${destination} ] || mkdir -p ${destination}
+[ -d "${destination}" ] || mkdir -p "${destination}"
 
 echo "Downloading and extracting ${app} ${ver} to ${destination}"
-curl -L -s ${downloadURL} -o - | tar xz -C ${destination}
+curl -L -s "${downloadURL}" -o - | tar xz -C "${destination}"
 
 echo 'Remember to add the pct app to your path:'
 echo 'export PATH=$PATH:'${destination}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -11,7 +11,7 @@ ext=".tar.gz"
 
 releases=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${org}/${repo}/releases")
 
-ver=$(echo $releases | grep -oE -m 1 '"tag_name": "(([0-9]+\.)+[0-9]+(-pre+)?)"' | cut -d '"' -f 4)
+ver=$(echo $releases | grep -oE -m 1 '"tag_name": "(([0-9]+\.)+[0-9]+(-pre+)?)"' | cut -d '"' -f 4 | head -1)
 
 file="${app}_${ver}_${os}_${arch}${ext}"
 


### PR DESCRIPTION
Installing pdkgo with the curl script today failed trying to extract
from the wrong URL, because the variable `$ver` had ended up with two
matches (`0.1.0 0.1.0-pre`).  

This patch:
* Ensures there will only be a single version in `$ver`
* Fails the script if it encounters errors
* Adds quotes around variables used as arguments, so spaces won't appear
  to be multiple arguments

PS: I left out `set -o pipefail` because POSIX sh doesn't support it,
but it be a would good idea, on account of all the piped commands.

Closes #125

<!--
Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/pdkgo/blob/main/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/pdkgo/blob/main/CODE_OF_CONDUCT.md

Submitting a Pull Request:

- Create a fork of this repo in Github
- Create a new branch `git checkout -b my-branch-name`
- Make you change, add tests, and ensure tests pass
- Do not reformat existing code, it makes it hard to see what has changed. Leave the formatting to us.
- Make sure your commit messages are in the proper format. If the commit addresses an issue filed in the project, start the first line of the commit with the prefix `GH-` and the issue number in parentheses `(GH-111)`. Then leave a detailed explanation of your change, so a person in the future can understand what your work does.
- Update the `Unreleased` section in the CHANGELOG.md with your change

THANKS!
-->
