### PR TITLE
(maint) ensure code quality check run the correct version of go 

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -1,5 +1,9 @@
 name: codequality
 on: [pull_request]
+
+env:
+  go_version: 1.16
+
 jobs:
   security:
     name: gosec, Inspects source code for security problems
@@ -15,15 +19,29 @@ jobs:
     name: fmt, makes sure there are no formatting issues
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+         go-version: ${{ env.go_version }}
+      -
+        name: Check out code
         uses: actions/checkout@v1
-      - name: Run fmt
+      -
+        name: Run fmt
         run: make format
   mod_tidy:
     name: go mod tidy, makes sure are dependencies are cool
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+         go-version: ${{ env.go_version }}
+      -
+        name: Check out code
         uses: actions/checkout@v1
-      - name: Run go mod tidy
+      -
+        name: Run go mod tidy
         run: make tidy


### PR DESCRIPTION
rule out that the go mod tidy issue observed [here](https://github.com/puppetlabs/pdkgo/runs/2792130365?check_suite_focus=true#step:3:5) is due to running a different version of go for the codequality checks