### PR TITLE
(GH-139) Fix version command release output

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -47,6 +47,6 @@ func changelogURL(version string) string {
 		return fmt.Sprintf("%s/releases/latest", path)
 	}
 
-	url := fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))
+	url := fmt.Sprintf("%s/releases/tag/%s", path, strings.TrimPrefix(version, "v"))
 	return url
 }


### PR DESCRIPTION
Remove the `v` prefix from the github release url generated when running `pct -v`. This project generates tags with just numbers and does not use the `v` prefix.
