### PR TITLE
(GH-145) Add ability to tar.gz a given template

### DIFF
--- a/internal/pkg/gzip/gzip_utils.go
+++ b/internal/pkg/gzip/gzip_utils.go
@@ -1,0 +1,11 @@
+package gzip
+
+type GzipHelpers interface {
+	Gzip(source, target string) (gzipFilePath string, err error)
+}
+
+type GzipHelpersImpl struct{}
+
+func (GzipHelpersImpl) Gzip(source, target string) (gzipFilePath string, err error) {
+	return Gzip(source, target)
+}

--- a/internal/pkg/pct/build.go
+++ b/internal/pkg/pct/build.go
@@ -1,0 +1,76 @@
+package pct
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/puppetlabs/pdkgo/internal/pkg/gzip"
+	"github.com/puppetlabs/pdkgo/internal/pkg/tar"
+	"github.com/puppetlabs/pdkgo/internal/pkg/utils"
+	"github.com/rs/zerolog/log"
+)
+
+var utilsHelper utils.UtilsHelper
+var osUtil utils.OsUtil
+var ioUtil utils.IoUtil
+var tarUtil tar.TarHelpers
+var gzipUtil gzip.GzipHelpers
+
+func init() {
+	utilsHelper = utils.UtilsHelperImpl{}
+	osUtil = utils.OsUtilHelpersImpl{}
+	ioUtil = utils.IoUtilHelpersImpl{}
+	tarUtil = tar.TarHelpersImpl{}
+	gzipUtil = gzip.GzipHelpersImpl{}
+}
+
+func Build(templatePath, targetDir string) (gzipArchiveFilePath string, err error) {
+	// Check we're in the root dir of a module before proceeding
+	wd, err := utilsHelper.IsModuleRoot()
+	if err != nil {
+		return "", fmt.Errorf("Could not determine if in module root dir: %v", err)
+	}
+	if wd == "" {
+		return "", fmt.Errorf("Not in current module root dir")
+	}
+
+	// Check template dir exists
+	if _, err := osUtil.Stat(templatePath); osUtil.IsNotExist(err) {
+		return "", err
+	}
+
+	// Check if pct-config.yml exists
+	if _, err := osUtil.Stat(filepath.Join(templatePath, "pct-config.yml")); osUtil.IsNotExist(err) {
+		return "", err
+	}
+
+	// Check if content dir exists
+	if _, err := osUtil.Stat(filepath.Join(templatePath, "content")); osUtil.IsNotExist(err) {
+		return "", err
+	}
+
+	// Create temp dir and TAR template there
+	tempDir, err := ioUtil.TempDir()
+	defer os.Remove(tempDir)
+
+	if err != nil {
+		log.Error().Msgf("Could not create tempdir to TAR template: %v", err)
+		return "", err
+	}
+
+	tarArchiveFilePath, err := tarUtil.Tar(templatePath, tempDir)
+	if err != nil {
+		log.Error().Msgf("Could not TAR template (%v): %v", templatePath, err)
+		return "", err
+	}
+
+	// GZIP the TAR created in the temp dir and output to the $MODULE_ROOT/pkg directory
+	gzipArchiveFilePath, err = gzipUtil.Gzip(tarArchiveFilePath, filepath.Join(wd, "pkg"))
+	if err != nil {
+		log.Error().Msgf("Could not GZIP template TAR archive (%v): %v", tarArchiveFilePath, err)
+		return "", err
+	}
+
+	return gzipArchiveFilePath, nil
+}

--- a/internal/pkg/pct/build_test.go
+++ b/internal/pkg/pct/build_test.go
@@ -1,0 +1,204 @@
+package pct
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuild(t *testing.T) {
+	utilsHelper = utilsHelperImplMock{}
+	osUtil = osUtilHelpersImplMock{}
+	tarUtil = tarHelpersImplMock{}
+	ioUtil = ioUtilHelpersImplMock{}
+	gzipUtil = gzipHelpersImplMock{}
+
+	type args struct {
+		templatePath string
+		targetDir    string
+	}
+
+	tests := []struct {
+		name                    string
+		args                    args
+		mockIsModuleRootErrResp error
+		mockStatResponses       []mockStatResponse
+		expectedFilePath        string
+		wantErr                 bool
+		mockTarErrResponse      error
+		mockGzipErrResponse     error
+		testTempDir             string
+	}{
+		{
+			name: "Should not attempt to package template if not in module root dir",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockIsModuleRootErrResp: errors.New("Not in module root dir"),
+			wantErr:                 true,
+			expectedFilePath:        "",
+		},
+		{
+			name: "Should return err if template path does not exist",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockStatResponses: []mockStatResponse{
+				{
+					// osUtil.Stat(templatePath)
+					expectedName: testDir,
+					mockError:    errors.New("Template path does not exist"),
+				},
+			},
+			expectedFilePath: "",
+			wantErr:          true,
+		},
+		{
+			name: "Should return err if template path does not contain pct-config.yml",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockStatResponses: []mockStatResponse{
+				{
+					// osUtil.Stat(templatePath)
+					expectedName: testDir,
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "pct-config.yml"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "pct-config.yml")),
+					mockError:    errors.New("No pct-config.yml found"),
+				},
+			},
+			expectedFilePath: "",
+			wantErr:          true,
+		},
+		{
+			name: "Should return err if content dir does not exist",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockStatResponses: []mockStatResponse{
+				{
+					// osUtil.Stat(templatePath)
+					expectedName: testDir,
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "pct-config.yml"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "pct-config.yml")),
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "content"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "content")),
+					mockError:    errors.New("No content dir found"),
+				},
+			},
+			expectedFilePath: "",
+			wantErr:          true,
+		},
+		{
+			name: "Should not attempt to GZIP when TAR operation fails",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockStatResponses: []mockStatResponse{
+				{
+					// osUtil.Stat(templatePath)
+					expectedName: testDir,
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "pct-config.yml"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "pct-config.yml")),
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "content"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "content")),
+					mockError:    nil,
+				},
+			},
+			expectedFilePath:   "",
+			wantErr:            true,
+			mockTarErrResponse: errors.New("Could not TAR the directory"),
+		},
+		{
+			name: "Should TAR.GZ valid template to $MODULE_ROOT/pkg and return path",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockStatResponses: []mockStatResponse{
+				{
+					// osUtil.Stat(templatePath)
+					expectedName: testDir,
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "pct-config.yml"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "pct-config.yml")),
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "content"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "content")),
+					mockError:    nil,
+				},
+			},
+			expectedFilePath:   filepath.Clean("/path/to/nowhere/pkg/template.tar.gz"),
+			wantErr:            false,
+			mockTarErrResponse: nil,
+		},
+		{
+			name: "Should return error and empty path is GZIP operation fails",
+			args: args{
+				templatePath: testDir,
+				targetDir:    testDir,
+			},
+			mockStatResponses: []mockStatResponse{
+				{
+					// osUtil.Stat(templatePath)
+					expectedName: testDir,
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "pct-config.yml"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "pct-config.yml")),
+					mockError:    nil,
+				},
+				{
+					// osUtil.Stat(filepath.Join(templatePath, "content"))
+					expectedName: filepath.Clean(filepath.Join(testDir, "content")),
+					mockError:    nil,
+				},
+			},
+			expectedFilePath:    "",
+			wantErr:             true,
+			mockTarErrResponse:  nil,
+			mockGzipErrResponse: errors.New("Could not GZIP the TAR"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockIsModuleRootErrResp = tt.mockIsModuleRootErrResp
+			mockStatResponses = tt.mockStatResponses
+			mockTarErrResponse = tt.mockTarErrResponse
+			mockGzipErrResponse = tt.mockGzipErrResponse
+			gotGzipArchiveFilePath, err := Build(tt.args.templatePath, tt.args.targetDir)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotGzipArchiveFilePath != tt.expectedFilePath {
+				t.Errorf("Build() = %v, want %v", gotGzipArchiveFilePath, tt.expectedFilePath)
+			}
+		})
+	}
+}

--- a/internal/pkg/pct/gzip_utils_mock.go
+++ b/internal/pkg/pct/gzip_utils_mock.go
@@ -1,0 +1,21 @@
+package pct
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+var mockGzipErrResponse error
+
+type gzipHelpersImplMock struct{}
+
+func (gzipHelpersImplMock) Gzip(source, target string) (gzipFilePath string, err error) {
+	if mockGzipErrResponse != nil {
+		return "", mockGzipErrResponse
+	}
+
+	if source == filepath.Join(testDir, "template.tar") {
+		return filepath.Join(target, "template.tar.gz"), nil
+	}
+	return "", fmt.Errorf("Called with unexpected source: %v", source)
+}

--- a/internal/pkg/pct/io_utils_mock.go
+++ b/internal/pkg/pct/io_utils_mock.go
@@ -1,0 +1,11 @@
+package pct
+
+import "path/filepath"
+
+var testDir string = filepath.Clean("/path/to/nowhere")
+
+type ioUtilHelpersImplMock struct{}
+
+func (ioUtilHelpersImplMock) TempDir() (name string, err error) {
+	return testDir, nil
+}

--- a/internal/pkg/pct/os_utils_mock.go
+++ b/internal/pkg/pct/os_utils_mock.go
@@ -1,0 +1,37 @@
+package pct
+
+import (
+	"io/fs"
+	"os"
+)
+
+type mockStatResponse struct {
+	expectedName string
+	mockError    error
+}
+
+type fileInfo = fs.FileInfo
+
+var fileInfoMock fileInfo
+
+var mockStatResponses []mockStatResponse
+var mockIsNotExistResponse bool
+
+type osUtilHelpersImplMock struct{}
+
+func (osUtilHelpersImplMock) Stat(name string) (os.FileInfo, error) {
+	mockIsNotExistResponse = false
+	for _, mockStatResponse := range mockStatResponses {
+		if name == mockStatResponse.expectedName {
+			if mockStatResponse.mockError != nil {
+				mockIsNotExistResponse = true
+			}
+			return fileInfoMock, mockStatResponse.mockError
+		}
+	}
+	return nil, nil
+}
+
+func (osUtilHelpersImplMock) IsNotExist(err error) bool {
+	return mockIsNotExistResponse
+}

--- a/internal/pkg/pct/tar_utils_mock.go
+++ b/internal/pkg/pct/tar_utils_mock.go
@@ -1,0 +1,21 @@
+package pct
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+var mockTarErrResponse error
+
+type tarHelpersImplMock struct{}
+
+func (tarHelpersImplMock) Tar(source, target string) (tarFilePath string, err error) {
+	if mockTarErrResponse != nil {
+		return "", mockTarErrResponse
+	}
+
+	if source == testDir {
+		return filepath.Join(testDir, "template.tar"), nil
+	}
+	return "", fmt.Errorf("Called with unexpected source: %v", source)
+}

--- a/internal/pkg/pct/utils_mock.go
+++ b/internal/pkg/pct/utils_mock.go
@@ -1,0 +1,14 @@
+package pct
+
+import "path/filepath"
+
+type utilsHelperImplMock struct{}
+
+var mockIsModuleRootErrResp error
+
+func (utilsHelperImplMock) IsModuleRoot() (string, error) {
+	if mockIsModuleRootErrResp != nil {
+		return "", mockIsModuleRootErrResp
+	}
+	return filepath.Clean(testDir), nil
+}

--- a/internal/pkg/tar/tar_utils.go
+++ b/internal/pkg/tar/tar_utils.go
@@ -1,0 +1,11 @@
+package tar
+
+type TarHelpers interface {
+	Tar(source, target string) (tarFilePath string, err error)
+}
+
+type TarHelpersImpl struct{}
+
+func (TarHelpersImpl) Tar(source, target string) (tarFilePath string, err error) {
+	return Tar(source, target)
+}

--- a/internal/pkg/utils/io_utils.go
+++ b/internal/pkg/utils/io_utils.go
@@ -1,0 +1,13 @@
+package utils
+
+import "io/ioutil"
+
+type IoUtil interface {
+	TempDir() (name string, err error)
+}
+
+type IoUtilHelpersImpl struct{}
+
+func (IoUtilHelpersImpl) TempDir() (name string, err error) {
+	return ioutil.TempDir("", "")
+}

--- a/internal/pkg/utils/os_utils.go
+++ b/internal/pkg/utils/os_utils.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"os"
+)
+
+type OsUtil interface {
+	Stat(string) (os.FileInfo, error)
+	IsNotExist(err error) bool
+}
+
+type OsUtilHelpersImpl struct{}
+
+func (OsUtilHelpersImpl) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (OsUtilHelpersImpl) IsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -3,12 +3,20 @@ package utils
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/puppetlabs/pdkgo/internal/pkg/pdkshell"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+type UtilsHelper interface {
+	IsModuleRoot() (string, error)
+}
+
+type UtilsHelperImpl struct{}
 
 // contains checks if a string is present in a slice
 func Contains(s []string, str string) bool {
@@ -100,4 +108,20 @@ func ChunkedCopy(dst io.Writer, src io.Reader) error {
 			return fmt.Errorf("Exceeded max copy size of %v", maxCopySize)
 		}
 	}
+}
+
+// Check if we're currently in the module root dir.
+// Return the sanitized file path if we are in a module root, otherwise an empty string.
+func (UtilsHelperImpl) IsModuleRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	_, err = os.Stat(filepath.Join(wd, "metadata.json"))
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Clean(wd), nil
 }


### PR DESCRIPTION
This commit adds the `build` method, which will take a given
template path and output dir, and generate a .tar.gz of the
template path's contents.

This work is built upon the previous effort in GH-137 which
implemented the TAR and GZIP utility methods.

Some preflight sanity checks are performed on the template path
to ensure it meets the minimum requirements of a PCT:

- Are we in a valid module's root dir?
- Does the directory path exist?
- Does it contain a `pct-config.yml` at root?
- Does it contain a `content` dir at root?

If those conditions are satisfied, the template directory is
first TAR'd and then GZIP'd, and the resulting `.tar.gz` output to
the specified directory.

If any operation fails along the way (pre checks / TAR/GZ operation),
an error is returned.

Closes: #145 