### PR TITLE
(GH-185) Validate a pct-config.yml before building 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [(GH-185)](https://github.com/puppetlabs/pdkgo/issues/185) `pct build` validates pct-config.yml
 - [(GH-167)](https://github.com/puppetlabs/pdkgo/issues/167) Implement `pct install` CLI command
 
 ## [0.3.0]

--- a/acceptance/build/testdata/good-project/pct-config.yml
+++ b/acceptance/build/testdata/good-project/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: good-project
+  author: puppetlabs
   type: project
   display: Good Project
   version: 0.1.0

--- a/acceptance/build/testdata/no-content-dir-project/pct-config.yml
+++ b/acceptance/build/testdata/no-content-dir-project/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: good-project
+  author: puppetlabs
   type: project
   display: Good Project
   version: 0.1.0

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,11 @@ switch ($Target) {
     git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round (Join-Path $binPath "templates")
   }
   'quick' {
-    go build -o ${binPath}/pct
+    If ($Env:OS -match '^Windows') {
+      go build -o "$binPath/pct.exe"
+    } else {
+      go build -o "$binPath/pct"
+    }
   }
   'package' {
     git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round "templates"

--- a/build.ps1
+++ b/build.ps1
@@ -3,20 +3,24 @@
 [CmdletBinding()]
 param (
   [Parameter()]
-  [ValidateSet('build', 'package')]
+  [ValidateSet('build', 'quick', 'package')]
   [string]
   $Target = 'build'
 )
 $Env:WORKINGDIR = $PSScriptRoot
 
+$arch = go env GOHOSTARCH
+$platform = go env GOHOSTOS
+$binPath = Join-Path $PSScriptRoot "dist" "pct_${platform}_${arch}"
+
 switch ($Target) {
   'build' {
-    $arch = go env GOHOSTARCH
-    $platform = go env GOHOSTOS
-    $binPath = Join-Path $PSScriptRoot "dist" "pct_${platform}_${arch}"
     # Set goreleaser to build for current platform only
     goreleaser build --snapshot --rm-dist --single-target
     git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round (Join-Path $binPath "templates")
+  }
+  'quick' {
+    go build -o ${binPath}/pct
   }
   'package' {
     git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round "templates"

--- a/build.sh
+++ b/build.sh
@@ -3,13 +3,16 @@
 export WORKINGDIR=$(pwd)
 
 target=${1:-build}
+arch=$(go env GOHOSTARCH)
+platform=$(go env GOHOSTOS)
+binPath="$(pwd)/dist/pct_${platform}_${arch}"
+
 if [ "$target" == "build" ]; then
-  arch=$(go env GOHOSTARCH)
-  platform=$(go env GOHOSTOS)
-  binPath="$(pwd)/dist/pct_${platform}_${arch}"
   # Set goreleaser to build for current platform only
   goreleaser build --snapshot --rm-dist --single-target
   git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round "$binPath/templates"
+elif [ "$target" == "quick" ]; then
+  go build -o ${binPath}/pct
 elif [ "$target" == "package" ]; then
   git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round "templates"
   goreleaser --skip-publish --snapshot --rm-dist

--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -43,7 +44,7 @@ func CreateCommand() *cobra.Command {
 func preExecute(cmd *cobra.Command, args []string) error {
 
 	wd, err := os.Getwd()
-	log.Info().Msgf("WD: %v", wd)
+	log.Trace().Msgf("WD: %v", wd)
 
 	if (sourceDir == "" || targetDir == "") && err != nil {
 		return err
@@ -62,6 +63,10 @@ func preExecute(cmd *cobra.Command, args []string) error {
 
 func execute(cmd *cobra.Command, args []string) error {
 	gzipArchiveFilePath, err := builder.Build(sourceDir, targetDir)
+
+	if err != nil {
+		return fmt.Errorf("`sourcedir` is not a valid template: %s", err.Error())
+	}
 	log.Info().Msgf("Template output to %v", gzipArchiveFilePath)
-	return err
+	return nil
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -47,6 +47,8 @@ func CreateRootCommand() *cobra.Command {
 		Long:  `Puppet Content Templater (PCT) - Create a range of Puppet content from templates`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	tmp.Flags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pdk.yaml)")
 

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -43,6 +43,7 @@ type PuppetContentTemplateInfo struct {
 // PuppetContentTemplate houses the actual information about each template
 type PuppetContentTemplate struct {
 	Id      string `mapstructure:"id"`
+	Author  string `mapstructure:"author"`
 	Type    string `mapstructure:"type"`
 	Display string `mapstructure:"display"`
 	Version string `mapstructure:"version"`


### PR DESCRIPTION
Ensures that the attributes of id, author and version are present within pct-config.yml. These are required for installing templates within a namespaces and version directory structure.
