### PR TITLE
(MAINT) Change `Mkdir(All)?` perms from 750 -> 0750

### DIFF
--- a/internal/pkg/pct/build_test.go
+++ b/internal/pkg/pct/build_test.go
@@ -131,7 +131,7 @@ func TestBuild(t *testing.T) {
 			afs := &afero.Afero{Fs: fs}
 
 			for _, path := range tt.mockDirs {
-				afs.Mkdir(path, 750) //nolint:gosec,errcheck // this result is not used in a secure application
+				afs.Mkdir(path, 0750) //nolint:gosec,errcheck // this result is not used in a secure application
 			}
 
 			for _, path := range tt.mockFiles {

--- a/internal/pkg/pct/pct_test.go
+++ b/internal/pkg/pct/pct_test.go
@@ -228,7 +228,7 @@ Summary: {{.example_replace.summary}}`,
 			// Create the template
 			templateDir := filepath.Join(tt.args.info.TemplateCache, tt.args.info.SelectedTemplate)
 			contentDir := filepath.Join(templateDir, "content")
-			afs.MkdirAll(contentDir, 750) //nolint:errcheck
+			afs.MkdirAll(contentDir, 0750) //nolint:errcheck
 			// Create template config
 			config, _ := afs.Create(filepath.Join(templateDir, "pct-config.yml"))
 			config.Write([]byte(tt.args.templateConfig)) //nolint:errcheck
@@ -313,7 +313,7 @@ template:
 				// Create the template
 				templateDir := filepath.Join(tt.args.templateCache, tt.args.selectedTemplate)
 				contentDir := filepath.Join(templateDir, "content")
-				afs.MkdirAll(contentDir, 750) //nolint:errcheck
+				afs.MkdirAll(contentDir, 0750) //nolint:errcheck
 				// Create template config
 				config, _ := afs.Create(filepath.Join(templateDir, "pct-config.yml"))
 				config.Write([]byte(tt.args.templateConfig)) //nolint:errcheck

--- a/internal/pkg/tar/tar_test.go
+++ b/internal/pkg/tar/tar_test.go
@@ -38,7 +38,7 @@ func TestTar(t *testing.T) {
 
 			fs := afero.NewMemMapFs()
 			afs := &afero.Afero{Fs: fs}
-			afs.MkdirAll(tt.args.source, 755) //nolint:errcheck
+			afs.MkdirAll(tt.args.source, 0750) //nolint:errcheck
 
 			tar := &tar.Tar{AFS: afs}
 			tarFilePath, err := tar.Tar(tt.args.source, tt.args.target)


### PR DESCRIPTION
Prior to this commit, when running linting checks locally, you
would encounter the following error:

```
SA9002: file mode '750' evaluates to 01356; did you mean '0750'
```

This commit fixes the perm value to avoid this error.

Also changes a `0755` perm setting to a more secure `0750` in
`tar_test.go`