### PR TITLE
(GH-184) Enable install of remote templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [(GH-184)](https://github.com/uppetlabs/pdkgo/issues/184) `pct install` works against remote `tar.gz` files
 - [(GH-185)](https://github.com/puppetlabs/pdkgo/issues/185) `pct build` validates pct-config.yml
 - [(GH-167)](https://github.com/puppetlabs/pdkgo/issues/167) Implement `pct install` CLI command
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,29 @@ The resulting `tar.gz` package will be created by default in `$cwd/pkg`. You can
 
 Packages created using the `build` command can be installed by extracting the `tar.gz` into  the **Default Template Location**.
 
+#### Local archive
+
+Packages created using the `build` command can also be installed with the `pct install` command.
+
+For example, this command:
+
+```bash
+pct install ~/my-template-1.2.3.tar.gz
+```
+
+Will install the template contained in `my-template-1.2.3.tar.gz` to the default template location.
+
+#### Remote archive
+
+Packages created using the `build` command can be automatically downloaded and extracted with `pct install` so long as you know the URL to where the archive is.
+
+For example, this command:
+
+```bash
+pct install https://packages.mycompany.com/pct/my-template-1.2.3.tar.gz
+```
+
+Will attempt to download the PCT template from the specified url and then afterward install it like any other locally available PCT template archive.
 
 ## Requesting a feature
 

--- a/internal/pkg/httpclient/httpclient.go
+++ b/internal/pkg/httpclient/httpclient.go
@@ -1,0 +1,11 @@
+package httpclient
+
+import "net/http"
+
+type HTTPClientI interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
+type HTTPClient struct {
+	Client *http.Client
+}

--- a/internal/pkg/mock/httpclient.go
+++ b/internal/pkg/mock/httpclient.go
@@ -1,0 +1,24 @@
+package mock
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type GetResponse struct {
+	RequestResponse *http.Response
+	ErrResponse     bool
+}
+
+type HTTPClient struct {
+	RequestResponse *http.Response
+	ErrResponse     bool
+}
+
+func (h *HTTPClient) Get(url string) (*http.Response, error) {
+	if h.ErrResponse {
+		return nil, fmt.Errorf("Web request error")
+	}
+
+	return h.RequestResponse, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/puppetlabs/pdkgo/cmd/build"
 	"github.com/puppetlabs/pdkgo/cmd/completion"
 	"github.com/puppetlabs/pdkgo/cmd/install"
@@ -43,10 +45,11 @@ func main() {
 	// install
 	installCmd := install.InstallCommand{
 		PctInstaller: &pct.PctInstaller{
-			Tar:    &tar.Tar{AFS: &afs},
-			Gunzip: &gzip.Gunzip{AFS: &afs},
-			AFS:    &afs,
-			IOFS:   &iofs,
+			Tar:        &tar.Tar{AFS: &afs},
+			Gunzip:     &gzip.Gunzip{AFS: &afs},
+			AFS:        &afs,
+			IOFS:       &iofs,
+			HTTPClient: &http.Client{},
 		},
 	}
 	rootCmd.AddCommand(installCmd.CreateCommand())


### PR DESCRIPTION
Prior to this commit the only way to install a PCT template was to have
already downloaded the tar.gz locally.

This commit updates the `Install` function to handle a `templatePkg`
specified as a valid URL, downloading the file to a temporary folder
and then handing the file off to the remainder of the function to
process like any local file.

This commit also implements the new `downloadTemplate` function, which
handles downloading and placing the template archive file, returning the
path to it.

TODO: unit/acceptance tests
