### PR TITLE
(GH-208) Port prototype of docker get/set for Puppet

### DIFF
--- a/cmd/pmr/get/get.go
+++ b/cmd/pmr/get/get.go
@@ -1,0 +1,29 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func CreateGetCommand() *cobra.Command {
+	tmp := &cobra.Command{
+		Use:   "get",
+		Short: "Gets PDK configuration",
+		Long:  `Gets PDK configuration`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.HelpFunc()(cmd, args)
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("This command does not take arguments, got %d", len(args))
+			}
+
+			return nil
+		},
+	}
+
+	tmp.AddCommand(CreateGetPuppetCommand())
+
+	return tmp
+}

--- a/cmd/pmr/get/puppet.go
+++ b/cmd/pmr/get/puppet.go
@@ -1,0 +1,28 @@
+package get
+
+import (
+	"github.com/puppetlabs/pdkgo/internal/pkg/config"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var PuppetVersion string
+
+func CreateGetPuppetCommand() *cobra.Command {
+	tmp := &cobra.Command{
+		Use:   "puppet",
+		Short: "Gets the Puppet version configured",
+		Long: `Gets the Puppet version configured
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			LogPuppetVersion()
+		},
+	}
+
+	return tmp
+}
+
+func LogPuppetVersion() {
+	log.Info().Msgf("Puppet version is configured to: %s", viper.GetString(config.PuppetVersion))
+}

--- a/cmd/pmr/main.go
+++ b/cmd/pmr/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"github.com/puppetlabs/pdkgo/cmd/pct/completion"
+	"github.com/puppetlabs/pdkgo/cmd/pmr/get"
 	"github.com/puppetlabs/pdkgo/cmd/pmr/root"
+	"github.com/puppetlabs/pdkgo/cmd/pmr/set"
 	appver "github.com/puppetlabs/pdkgo/cmd/pmr/version"
 
 	"github.com/spf13/cobra"
@@ -22,6 +24,9 @@ func main() {
 	rootCmd.Version = v
 	rootCmd.SetVersionTemplate(v)
 	rootCmd.AddCommand(verCmd)
+
+	rootCmd.AddCommand(set.CreateSetCommand())
+	rootCmd.AddCommand(get.CreateGetCommand())
 
 	rootCmd.AddCommand(completion.CreateCompletionCommand())
 

--- a/cmd/pmr/set/puppet.go
+++ b/cmd/pmr/set/puppet.go
@@ -33,6 +33,7 @@ func CreateSetPuppetCommand() *cobra.Command {
 	}
 
 	tmp.PersistentFlags().StringVar(&PuppetVersion, "version", zerolog.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	/* #nosec G104 */
 	tmp.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) { //nolint:errcheck
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/pmr/set/puppet.go
+++ b/cmd/pmr/set/puppet.go
@@ -1,0 +1,56 @@
+package set
+
+import (
+	"github.com/puppetlabs/pdkgo/cmd/pmr/get"
+	"github.com/puppetlabs/pdkgo/internal/pkg/config"
+	"github.com/puppetlabs/pdkgo/internal/pkg/puppet"
+	"github.com/puppetlabs/pdkgo/internal/pkg/utils"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var PuppetVersion string
+
+func CreateSetPuppetCommand() *cobra.Command {
+	tmp := &cobra.Command{
+		Use:   "puppet",
+		Short: "Sets the Puppet version to use with the PDK",
+		Long: `Sets the Puppet version to use with the PDK.
+		REQUIRES DOCKER.
+		This will:
+			* Download a docker image containing the PDK toolchain for the version of Puppet you set.
+			* Stand up the container
+			* Link the PDK to the container for all subsequent functions.
+			* The setting will persist until called again.
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			configurePuppet(args)
+		},
+		ValidArgs: []string{"5.5.0", "6.15.0", "7.5.0"},
+		Args:      cobra.ExactValidArgs(1),
+	}
+
+	tmp.PersistentFlags().StringVar(&PuppetVersion, "version", zerolog.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	tmp.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) { //nolint:errcheck
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var levels = []string{"debug", "info", "warn", "error", "fatal", "panic"}
+		return utils.Find(levels, toComplete), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return tmp
+}
+
+func configurePuppet(args []string) {
+	viper.Set(config.PuppetVersion, args[0])
+	if err := viper.WriteConfig(); err != nil {
+		log.Error().Msg(err.Error())
+	}
+
+	puppet.StopContainer()
+	puppet.StartContainer(viper.GetString(config.PuppetVersion))
+	get.LogPuppetVersion()
+}

--- a/cmd/pmr/set/set.go
+++ b/cmd/pmr/set/set.go
@@ -1,0 +1,29 @@
+package set
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func CreateSetCommand() *cobra.Command {
+	tmp := &cobra.Command{
+		Use:   "set",
+		Short: "Sets configuration for PDK",
+		Long:  `Sets configuration for PDK`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.HelpFunc()(cmd, args)
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("This command does not take arguments, got %d", len(args))
+			}
+
+			return nil
+		},
+	}
+
+	tmp.AddCommand(CreateSetPuppetCommand())
+
+	return tmp
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -1,0 +1,9 @@
+package config
+
+// Contains the constants mapping the config path strings
+// for use with the .pmr.yaml config file
+
+const (
+	PuppetVersion  = "puppet.version"
+	ToolchainMount = "pmr.toolchain.mount"
+)

--- a/internal/pkg/puppet/container.go
+++ b/internal/pkg/puppet/container.go
@@ -14,6 +14,7 @@ func StartContainer(puppetVersion string) {
 	containerName := fmt.Sprintf("puppet/puppet-agent:%s", puppetVersion)
 	log.Info().Msgf("Starting container `%s`", containerName)
 
+	/* #nosec G204 */
 	runCommand := exec.Command("docker", "run", "--rm", "-i", "-d", "--name", "pdk-toolchain", "-v", "/toolchain", containerName)
 
 	if err := runCommand.Run(); err != nil {

--- a/internal/pkg/puppet/container.go
+++ b/internal/pkg/puppet/container.go
@@ -1,0 +1,58 @@
+package puppet
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/puppetlabs/pdkgo/internal/pkg/config"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+)
+
+func StartContainer(puppetVersion string) {
+	containerName := fmt.Sprintf("puppet/puppet-agent:%s", puppetVersion)
+	log.Info().Msgf("Starting container `%s`", containerName)
+
+	runCommand := exec.Command("docker", "run", "--rm", "-i", "-d", "--name", "pdk-toolchain", "-v", "/toolchain", containerName)
+
+	if err := runCommand.Run(); err != nil {
+		log.Error().Msgf("Unable to start the toolchain: %s", err.Error())
+	}
+
+	storeMount()
+}
+
+func StopContainer() {
+	log.Info().Msgf("Stopping toolchain container")
+
+	runCommand := exec.Command("docker", "stop", "pdk-toolchain")
+
+	if err := runCommand.Run(); err != nil {
+		if exiterr, _ := err.(*exec.ExitError); exiterr.ExitCode() > 1 {
+			log.Error().Msgf("Unable to stop the toolchain container: %s", exiterr.Error())
+		}
+	}
+
+}
+
+func storeMount() {
+	runCommand, err := exec.Command("docker", "container", "inspect", "-f '{{ (index .Mounts 0).Source }}'", "pdk-toolchain").Output()
+
+	if err != nil {
+		log.Error().Msgf("Failed to record toolchain mount location: %s", err.Error())
+		return
+	}
+
+	mountPath := strings.Trim(string(runCommand), "\n' ")
+	log.Info().Msgf("mount location: %s", mountPath)
+
+	viper.Set(config.ToolchainMount, mountPath)
+	if err := viper.WriteConfig(); err != nil {
+		log.Error().Msgf("Failed to save mountpath to config: %s", err.Error())
+	}
+}
+
+func GetToolchainPath() string {
+	return viper.GetString(config.ToolchainMount)
+}


### PR DESCRIPTION
This commit pulls the work @da-ar did in his docker POC:

- https://github.com/da-ar/pdkgo/commits/version-poc

To the PRM binary, reworking it slightly where needed. This commit does not add or change any functionality, merely moves it into the correct binary.

What this PR currently enables:

- Setting/Getting the version of the Puppet Runtime available as a docker container to PRM.

Future PRs will be needed to generalize and productize these basic interfaces.

Resolves #209 