### PR TITLE
(GH-223) Implement UUID for telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/puppetlabs/pdkgo
 go 1.16
 
 require (
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"runtime"
 
+	"github.com/denisbrodbeck/machineid"
 	"github.com/rs/zerolog/log"
 
 	"go.opentelemetry.io/otel"
@@ -59,6 +60,7 @@ func Start(ctx context.Context, honeycomb_api_key string, honeycomb_dataset stri
 
 	tracer := otel.Tracer("pct")
 
+	uuid := attribute.Key("uuid")
 	osKey := attribute.Key("osinfo/os")
 	osArch := attribute.Key("osinfo/arch")
 
@@ -66,6 +68,11 @@ func Start(ctx context.Context, honeycomb_api_key string, honeycomb_dataset stri
 	_, span = tracer.Start(ctx, "execution")
 	defer span.End()
 
+	// The Protected ID is hashed base on application name to prevent any
+	// accidental leakage of a reversable ID.
+	machineUUID, _ := machineid.ProtectedID("pdk")
+
+	span.SetAttributes(uuid.String(machineUUID))
 	span.SetAttributes(osKey.String(runtime.GOOS))
 	span.SetAttributes(osArch.String(runtime.GOARCH))
 }


### PR DESCRIPTION
Prior to this commit, a binary reporting telemetry would report on the Operating System and Architecture of the machine PCT was running on; this commit adds a new data key for UUID to enable per-machine telemetry and analysis.

The UUID itself is further hashed to our own namespace to prevent even the possibility of leaking a UUID which could be reversed to discover the user.

Resolves #223 