### PR TITLE
(GH-295) Add documentation site install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ templates/
 
 ./pdk
 ./pct
+
+# Documentation site
+docs/site

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ draft: false
 * [Sharing Templates](#sharing-templates)
   * [pct build](#pct-build)
   * [Installing template packages](#installing-template-packages)
+* [Locally host documentation site](#locally-host-documentation-site)
+  * [Prerequisites](#prerequisites)
+  * [Install site](#install-site)
+  * [Run site](#run-site)
 * [Request a feature](#request-a-feature)
 * [Reporting Problems](#reporting-problems)
 * [Installing Telemetry Free Version](#installing-telemetry-free-version)
-
 ## Overview
 
 Puppet Content Templates (PCT) codify a structure to produce content for any Puppet Product that can be authored by Puppet Product Teams or external users without direct help of the PDK team.
@@ -442,6 +445,47 @@ pct install --git-uri https://github.com/myorg/myawesometemplate
 ```
 
 This will attempt to clone the PCT template from the git repository at the specified URI and install to the default template location.
+
+## Locally host documentation site
+
+The DevX documentation site can be locally hosted and changes made to the markdown files inside of the `docs/md/content` directory will
+be visible on the site.
+
+### Prerequisites
+
+Essential software that will need to be installed to run the documentation site locally:
+
+- Git version control
+- Hugo extended version
+- Nodejs and NPM
+
+### Install site
+
+To install the documentation site run the following command from the root of this project:
+
+```bash
+./docs.sh
+```
+
+This will install and run the documentation site. The site can be found at `http://localhost:1313`. All updates will to the
+`docs/md/content` directory will hot reload the site.
+
+To stop the running `ctrl + c` in the terminal window in which it is running.
+
+### Run site
+
+Commands to run the site locally:
+```bash
+# Run without draft pages being displayed
+./docs.sh
+```
+or
+
+```bash
+# Run with draft pages being displayed
+./docs.sh -D
+```
+
 
 ## Requesting a feature
 

--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Check working directory is the root directory of the PDKGO repository
+if [ ! -d "docs/md" ]; then
+    echo 'Please run this script from the root directory of the PDKGO project.'
+    exit 1
+fi
+# Check hugo extended is installed
+if ! hugo version | grep -q 'extended'; then
+    echo 'The "extended" version of hugo was not found, please install it.'
+    exit
+fi
+# Check git is installed
+if ! type "git" > /dev/null; then
+    echo "Git version control was not found, please install it."
+    exit
+fi
+# Check if npm is installed
+if ! type "npm" > /dev/null; then
+    echo "NPM was not found, please install it."
+    exit
+fi
+
+if [ ! -d "docs/site" ]; then
+    git clone https://github.com/puppetlabs/devx.git docs/site
+    cd docs/site
+    echo "replace github.com/puppetlabs/pdkgo/docs/md => ../md" >> go.mod
+    npm install
+else
+    cd docs/site
+    git pull
+    hugo mod clean
+fi
+
+# Check for -D flag to see if user wants to run the site with draft pages displayed
+flag=''
+while getopts 'D' opt; do
+    case $opt in
+        D) flag='-D' ;;
+    esac
+done
+
+git submodule update --init --recursive --depth 50
+hugo mod get
+hugo server $flag


### PR DESCRIPTION
Overview of PR:

- Added the `docs.sh` script that installs the devx documentation site to the `docs/site` 
directory of the project.
- Added instructions pertaining to the local installation and running of the
documentation site.

Resolves: #295 