### PR TITLE
(GH-309) Genericise `acceptance/testutils` package

### DIFF
--- a/acceptance/build/build_test.go
+++ b/acceptance/build/build_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const APP = "pct"
+
 func Test_PctBuild_Outputs_TarGz(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	templateName := "good-project"
 
@@ -19,7 +22,7 @@ func Test_PctBuild_Outputs_TarGz(t *testing.T) {
 	wd := testutils.GetTmpDir(t)
 
 	cmd := fmt.Sprintf("build --sourcedir %v --targetdir %v", templateDir, wd)
-	stdout, stderr, exitCode := testutils.RunPctCommand(cmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(cmd, "")
 
 	expectedOutputFilePath := filepath.Join(wd, fmt.Sprintf("%v.tar.gz", templateName))
 
@@ -31,6 +34,7 @@ func Test_PctBuild_Outputs_TarGz(t *testing.T) {
 
 func Test_PctBuild_With_NoTargetDir_Outputs_TarGz(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	templateName := "good-project"
 
@@ -39,7 +43,7 @@ func Test_PctBuild_With_NoTargetDir_Outputs_TarGz(t *testing.T) {
 	wd := testutils.GetTmpDir(t)
 
 	cmd := fmt.Sprintf("build --sourcedir %v", templateDir)
-	stdout, stderr, exitCode := testutils.RunPctCommand(cmd, wd)
+	stdout, stderr, exitCode := testutils.RunAppCommand(cmd, wd)
 
 	expectedOutputFilePath := filepath.Join(wd, "pkg", fmt.Sprintf("%v.tar.gz", templateName))
 
@@ -51,6 +55,7 @@ func Test_PctBuild_With_NoTargetDir_Outputs_TarGz(t *testing.T) {
 
 func Test_PctBuild_With_EmptySourceDir_Errors(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	templateName := "no-project-here"
 
@@ -58,7 +63,7 @@ func Test_PctBuild_With_EmptySourceDir_Errors(t *testing.T) {
 	templateDir := filepath.Join(sourceDir, templateName)
 
 	cmd := fmt.Sprintf("build --sourcedir %v", templateDir)
-	stdout, stderr, exitCode := testutils.RunPctCommand(cmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(cmd, "")
 
 	assert.Contains(t, stdout, fmt.Sprintf("No template directory at %v", templateDir))
 	assert.Equal(t, "exit status 1", stderr)
@@ -67,6 +72,7 @@ func Test_PctBuild_With_EmptySourceDir_Errors(t *testing.T) {
 
 func Test_PctBuild_With_NoPctConfig_Errors(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	templateName := "no-pct-config-project"
 
@@ -74,7 +80,7 @@ func Test_PctBuild_With_NoPctConfig_Errors(t *testing.T) {
 	templateDir := filepath.Join(sourceDir, templateName)
 
 	cmd := fmt.Sprintf("build --sourcedir %v", templateDir)
-	stdout, stderr, exitCode := testutils.RunPctCommand(cmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(cmd, "")
 
 	assert.Contains(t, stdout, fmt.Sprintf("No 'pct-config.yml' found in %v", templateDir))
 	assert.Equal(t, "exit status 1", stderr)
@@ -83,6 +89,7 @@ func Test_PctBuild_With_NoPctConfig_Errors(t *testing.T) {
 
 func Test_PctBuild_With_NoContentDir_Errors(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	templateName := "no-content-dir-project"
 
@@ -90,7 +97,7 @@ func Test_PctBuild_With_NoContentDir_Errors(t *testing.T) {
 	templateDir := filepath.Join(sourceDir, templateName)
 
 	cmd := fmt.Sprintf("build --sourcedir %v", templateDir)
-	stdout, stderr, exitCode := testutils.RunPctCommand(cmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(cmd, "")
 
 	assert.Contains(t, stdout, fmt.Sprintf("No 'content' dir found in %v", templateDir))
 	assert.Equal(t, "exit status 1", stderr)

--- a/acceptance/install/install_test.go
+++ b/acceptance/install/install_test.go
@@ -10,17 +10,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const APP = "pct"
+
 var defaultTemplatePath string
 
 func Test_PctInstall_InstallsTo_DefaultTemplatePath(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePkgPath, _ := filepath.Abs(fmt.Sprintf("../../acceptance/install/testdata/%v.tar.gz", "good-project"))
 	installCmd := fmt.Sprintf("install %v", templatePkgPath)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Assert
 	assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(getDefaultTemplatePath(), "gooder", "good-project", "0.1.0")))
@@ -30,7 +33,7 @@ func Test_PctInstall_InstallsTo_DefaultTemplatePath(t *testing.T) {
 	assert.FileExists(t, filepath.Join(getDefaultTemplatePath(), "gooder", "good-project", "0.1.0", "content", "empty.txt"))
 	assert.FileExists(t, filepath.Join(getDefaultTemplatePath(), "gooder", "good-project", "0.1.0", "content", "goodfile.txt.tmpl"))
 
-	stdout, stderr, exitCode = testutils.RunPctCommand("new --list", "")
+	stdout, stderr, exitCode = testutils.RunAppCommand("new --list", "")
 	assert.Regexp(t, "Good\\sProject\\s+\\|\\sgooder\\s+\\|\\sgood-project\\s+\\|\\sproject", stdout)
 	assert.Equal(t, "", stderr)
 	assert.Equal(t, 0, exitCode)
@@ -49,6 +52,7 @@ type templateData struct {
 
 func Test_PctInstall_InstallsTo_DefinedTemplatePath(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePath := testutils.GetTmpDir(t)
@@ -82,7 +86,7 @@ func Test_PctInstall_InstallsTo_DefinedTemplatePath(t *testing.T) {
 		installCmd := fmt.Sprintf("install %v --templatepath %v", templatePkgPath, templatePath)
 
 		// Exec
-		stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+		stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 		// Assert
 		assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, template.author, template.name, "0.1.0")))
@@ -97,7 +101,7 @@ func Test_PctInstall_InstallsTo_DefinedTemplatePath(t *testing.T) {
 		}
 
 		listCmd := fmt.Sprintf("new --list --templatepath %v", templatePath)
-		stdout, stderr, exitCode := testutils.RunPctCommand(listCmd, "")
+		stdout, stderr, exitCode := testutils.RunAppCommand(listCmd, "")
 
 		assert.Regexp(t, template.listExpRegex, stdout)
 		assert.Equal(t, "", stderr)
@@ -112,6 +116,7 @@ func Test_PctInstall_InstallsTo_DefinedTemplatePath(t *testing.T) {
 
 func Test_PctInstall_InstallsFrom_RemoteTemplatePath(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePath := testutils.GetTmpDir(t)
@@ -145,7 +150,7 @@ func Test_PctInstall_InstallsFrom_RemoteTemplatePath(t *testing.T) {
 		installCmd := fmt.Sprintf("install %v --templatepath %v", templatePkgPath, templatePath)
 
 		// Exec
-		stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+		stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 		// Assert
 		assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, template.author, template.name, "0.1.0")))
@@ -160,7 +165,7 @@ func Test_PctInstall_InstallsFrom_RemoteTemplatePath(t *testing.T) {
 		}
 
 		listCmd := fmt.Sprintf("new --list --templatepath %v", templatePath)
-		stdout, stderr, exitCode := testutils.RunPctCommand(listCmd, "")
+		stdout, stderr, exitCode := testutils.RunAppCommand(listCmd, "")
 
 		assert.Regexp(t, template.listExpRegex, stdout)
 		assert.Equal(t, "", stderr)
@@ -175,9 +180,10 @@ func Test_PctInstall_InstallsFrom_RemoteTemplatePath(t *testing.T) {
 
 func Test_PctInstall_Errors_When_NoTemplatePkgDefined(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand("install", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("install", "")
 
 	// Assert
 	assert.Contains(t, stdout, "Path to template package (tar.gz) should be first argument")
@@ -187,13 +193,14 @@ func Test_PctInstall_Errors_When_NoTemplatePkgDefined(t *testing.T) {
 
 func Test_PctInstall_Errors_When_TemplatePkgNotExist(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePkgPath, _ := filepath.Abs("/path/to/nowhere/good-project.tar.gz")
 	installCmd := fmt.Sprintf("install %v", templatePkgPath)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Assert
 	assert.Contains(t, stdout, fmt.Sprintf("No template package at %v", templatePkgPath))
@@ -203,13 +210,14 @@ func Test_PctInstall_Errors_When_TemplatePkgNotExist(t *testing.T) {
 
 func Test_PctInstall_Errors_When_InvalidGzProvided(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePkgPath, _ := filepath.Abs("../../acceptance/install/testdata/invalid-gz-project.tar.gz")
 	installCmd := fmt.Sprintf("install %v", templatePkgPath)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Assert
 	assert.Contains(t, stdout, fmt.Sprintf("Could not extract TAR from GZIP (%v)", templatePkgPath))
@@ -219,13 +227,14 @@ func Test_PctInstall_Errors_When_InvalidGzProvided(t *testing.T) {
 
 func Test_PctInstall_Errors_When_InvalidTarProvided(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePkgPath, _ := filepath.Abs("../../acceptance/install/testdata/invalid-tar-project.tar.gz")
 	installCmd := fmt.Sprintf("install %v", templatePkgPath)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Assert
 	assert.Contains(t, stdout, fmt.Sprintf("Could not UNTAR template (%v)", templatePkgPath))
@@ -235,6 +244,7 @@ func Test_PctInstall_Errors_When_InvalidTarProvided(t *testing.T) {
 
 func Test_PctInstall_FailsWhenTemplateAlreadyExists(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePath := testutils.GetTmpDir(t)
@@ -242,7 +252,7 @@ func Test_PctInstall_FailsWhenTemplateAlreadyExists(t *testing.T) {
 	// Install template
 	templatePkgPath, _ := filepath.Abs("../../acceptance/install/testdata/additional-project.tar.gz")
 	installCmd := fmt.Sprintf("install %v --templatepath %v", templatePkgPath, templatePath)
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// verify the template installed
 	assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, "adder", "additional-project", "0.1.0")))
@@ -252,7 +262,7 @@ func Test_PctInstall_FailsWhenTemplateAlreadyExists(t *testing.T) {
 	// Attempt to reinstall the template
 	templatePkgPath, _ = filepath.Abs("../../acceptance/install/testdata/additional-project.tar.gz")
 	installCmd = fmt.Sprintf("install %v --templatepath %v", templatePkgPath, templatePath)
-	stdout, stderr, exitCode = testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode = testutils.RunAppCommand(installCmd, "")
 
 	// verify that the template failed to install
 	assert.Contains(t, stdout, "Unable to install in namespace: Template already installed")
@@ -265,6 +275,7 @@ func Test_PctInstall_FailsWhenTemplateAlreadyExists(t *testing.T) {
 
 func Test_PctInstall_ForceSuccessWhenTemplateAlreadyExists(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePath := testutils.GetTmpDir(t)
@@ -272,7 +283,7 @@ func Test_PctInstall_ForceSuccessWhenTemplateAlreadyExists(t *testing.T) {
 	// Install template
 	templatePkgPath, _ := filepath.Abs("../../acceptance/install/testdata/additional-project.tar.gz")
 	installCmd := fmt.Sprintf("install %v --templatepath %v", templatePkgPath, templatePath)
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// verify the template installed
 	assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, "adder", "additional-project", "0.1.0")))
@@ -282,7 +293,7 @@ func Test_PctInstall_ForceSuccessWhenTemplateAlreadyExists(t *testing.T) {
 	// Attempt to reinstall the template
 	templatePkgPath, _ = filepath.Abs("../../acceptance/install/testdata/additional-project.tar.gz")
 	installCmd = fmt.Sprintf("install %v --force --templatepath %v", templatePkgPath, templatePath)
-	stdout, stderr, exitCode = testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode = testutils.RunAppCommand(installCmd, "")
 
 	// verify that the template reinstall exited successfully
 	assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, "adder", "additional-project", "0.1.0")))
@@ -330,6 +341,7 @@ func getDefaultTemplatePath() string {
 
 func Test_PctInstall_WithGitUri_InstallTemplate(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePath := testutils.GetTmpDir(t)
@@ -359,7 +371,7 @@ func Test_PctInstall_WithGitUri_InstallTemplate(t *testing.T) {
 		installCmd := fmt.Sprintf("install --git-uri %v --templatepath %v", template.gitUri, templatePath)
 
 		// Exec
-		stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+		stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 		// Assert
 		assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, template.author, template.name, "0.1.0")))
@@ -374,7 +386,7 @@ func Test_PctInstall_WithGitUri_InstallTemplate(t *testing.T) {
 		}
 
 		listCmd := fmt.Sprintf("new --list --templatepath %v", templatePath)
-		stdout, stderr, exitCode := testutils.RunPctCommand(listCmd, "")
+		stdout, stderr, exitCode := testutils.RunAppCommand(listCmd, "")
 
 		assert.Regexp(t, template.listExpRegex, stdout)
 		assert.Equal(t, "", stderr)
@@ -389,9 +401,10 @@ func Test_PctInstall_WithGitUri_InstallTemplate(t *testing.T) {
 
 func Test_PctInstall_WithGitUri_FailsWithNonExistentUri(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand("install --git-uri https://example.com/fake-git-uri", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("install --git-uri https://example.com/fake-git-uri", "")
 
 	// Assert
 	assert.Contains(t, stdout, "Could not clone git repository:")
@@ -401,9 +414,10 @@ func Test_PctInstall_WithGitUri_FailsWithNonExistentUri(t *testing.T) {
 
 func Test_PctInstall_WithGitUri_FailsWithInvalidUri(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Exec
-	stdout, stderr, exitCode := testutils.RunPctCommand("install --git-uri example.com/invalid-git-uri", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("install --git-uri example.com/invalid-git-uri", "")
 
 	// Assert
 	assert.Contains(t, stdout, "Could not parse template uri")
@@ -413,13 +427,14 @@ func Test_PctInstall_WithGitUri_FailsWithInvalidUri(t *testing.T) {
 
 func Test_PctInstall_WithGitUri_RemovesHiddenGitDir(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
 	// Setup
 	templatePath := testutils.GetTmpDir(t)
 
 	// Install template
 	installCmd := fmt.Sprint("install --git-uri https://github.com/puppetlabs/pct-test-template-01.git --templatepath ", templatePath)
-	stdout, stderr, exitCode := testutils.RunPctCommand(installCmd, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Verify the template installed
 	assert.Contains(t, stdout, fmt.Sprintf("Template installed to %v", filepath.Join(templatePath, "test-user", "test-template-1", "0.1.0")))

--- a/acceptance/new/new_test.go
+++ b/acceptance/new/new_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const APP = "pct"
+
 var templatePath string
 
 func TestMain(m *testing.M) {
@@ -27,8 +29,9 @@ func TestMain(m *testing.M) {
 
 func TestPctNew(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("new", "")
 	assert.Contains(t, stdout, "DISPLAYNAME")
 	assert.Contains(t, stdout, "AUTHOR")
 	assert.Contains(t, stdout, "NAME")
@@ -39,8 +42,9 @@ func TestPctNew(t *testing.T) {
 
 func TestPctNewUnknownTag(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new --foo", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("new --foo", "")
 	assert.Contains(t, stdout, "unknown flag: --foo")
 	assert.Equal(t, "exit status 1", stderr)
 	assert.Equal(t, 1, exitCode)
@@ -48,8 +52,9 @@ func TestPctNewUnknownTag(t *testing.T) {
 
 func TestPctNewTemplatePath(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new --templatepath "+templatePath, "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("new --templatepath "+templatePath, "")
 	assert.Contains(t, stdout, "DISPLAYNAME")
 	assert.Contains(t, stdout, "NAME")
 	assert.Contains(t, stdout, "TYPE")
@@ -60,8 +65,9 @@ func TestPctNewTemplatePath(t *testing.T) {
 
 func TestPctNewUnknownTemplate(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new foo/bar", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("new foo/bar", "")
 	assert.Contains(t, stdout, "Error: Couldn't find an installed template that matches 'foo/bar'")
 	assert.Equal(t, "exit status 1", stderr)
 	assert.Equal(t, 1, exitCode)
@@ -69,8 +75,9 @@ func TestPctNewUnknownTemplate(t *testing.T) {
 
 func TestPctNewAuthorNoId(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new puppetlabs", "")
+	stdout, stderr, exitCode := testutils.RunAppCommand("new puppetlabs", "")
 	assert.Contains(t, stdout, "Error: Selected template must be in AUTHOR/ID format")
 	assert.Equal(t, "exit status 1", stderr)
 	assert.Equal(t, 1, exitCode)
@@ -78,8 +85,9 @@ func TestPctNewAuthorNoId(t *testing.T) {
 
 func TestPctNewKnownTemplate(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new puppetlabs/full-project --templatepath "+templatePath, os.TempDir())
+	stdout, stderr, exitCode := testutils.RunAppCommand("new puppetlabs/full-project --templatepath "+templatePath, os.TempDir())
 	assert.Contains(t, stdout, "Deployed:")
 	assert.Equal(t, "", stderr)
 	assert.Equal(t, 0, exitCode)
@@ -87,8 +95,9 @@ func TestPctNewKnownTemplate(t *testing.T) {
 
 func TestPctNewInfo(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new --info puppetlabs/full-project --templatepath "+templatePath, os.TempDir())
+	stdout, stderr, exitCode := testutils.RunAppCommand("new --info puppetlabs/full-project --templatepath "+templatePath, os.TempDir())
 
 	expectedYaml := `puppet_module:
   license: Apache-2.0
@@ -115,8 +124,9 @@ func TestPctNewInfo(t *testing.T) {
 
 func TestPctNewInfoJson(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SetAppName(APP)
 
-	stdout, stderr, exitCode := testutils.RunPctCommand("new --info puppetlabs/full-project --format json --templatepath "+templatePath, os.TempDir())
+	stdout, stderr, exitCode := testutils.RunAppCommand("new --info puppetlabs/full-project --format json --templatepath "+templatePath, os.TempDir())
 
 	expectedJson := `{
   "puppet_module": {

--- a/acceptance/testutils/testutils.go
+++ b/acceptance/testutils/testutils.go
@@ -13,6 +13,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var app string
+
+func SetAppName(appName string) {
+	app = appName
+}
+
 func SkipAcceptanceTest(t *testing.T) {
 	if _, present := os.LookupEnv("TEST_ACCEPTANCE"); !present {
 		t.Skip("Skipping, Acceptance test")
@@ -43,22 +49,22 @@ func RunCommand(cmdString string, wd string) (stdout string, stderr string, exit
 	return stdout, stderr, exitCode
 }
 
-// Wraps RunCommand for PCT calls, locating the correct binary for the executing OS
-func RunPctCommand(cmdString string, wd string) (stdout string, stderr string, exitCode int) {
-	// where is pct built for this current OS?
+// Wraps RunCommand for App calls, locating the correct binary for the executing OS
+func RunAppCommand(cmdString string, wd string) (stdout string, stderr string, exitCode int) {
+	// where is app built for this current OS?
 	postfix := ""
 	if runtime.GOOS == "windows" {
 		postfix = ".exe"
 	}
 
-	pctPath := fmt.Sprintf("../../dist/pct_%s_%s/pct%s", runtime.GOOS, runtime.GOARCH, postfix)
-	absPath, err := filepath.Abs(pctPath)
+	appPath := fmt.Sprintf("../../dist/%s_%s_%s/%s%s", app, runtime.GOOS, runtime.GOARCH, app, postfix)
+	absPath, err := filepath.Abs(appPath)
 
 	if err != nil {
-		log.Error().Msgf("Unable to run create path for %s: %s", pctPath, err.Error())
+		log.Error().Msgf("Unable to run create path for %s: %s", appPath, err.Error())
 	}
 
-	log.Debug().Msgf("Testing Command: pct %s", cmdString)
+	log.Debug().Msgf("Testing Command: %s %s", app, cmdString)
 
 	executeString := fmt.Sprintf("%s %s", absPath, cmdString)
 


### PR DESCRIPTION
Prior to this commit, the utility functions within the `testutils`
package were working on the assumption that `pct` was the only
binary we would need to invoke for acceptance tests.

This commit genericises the utility methods by:
- Adding a `SetAppName` function
- Replacing any hardcoded string literals of "pct" and referencing
the `app` var set by `SetAppName`
- Renamed the `RunPctCommand` func to `RunAppCommand`

This change will allow us to import this package in to other
repos and use it for acceptance tests there. The first use case
will be for `puppetlabs/prm`.

Also part of this commit is the update of the tests that live in
the `acceptance` dir based on the above changes

Resolves: #309 