### PR TITLE
(MAINT) Fix format autocomplete for new command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [(GH-285)](https://github.com/puppetlabs/pdkgo/issues/285) Ensure running PCT without arguments does not fail unexpectedly.
 - [(GH-287)](https://github.com/puppetlabs/pdkgo/issues/287) Ensure a misconfigured telemetry binary fails early and cleanly.
+- [(GH-312)](https://github.com/puppetlabs/pdkgo/issues/312) Ensure that the format flag correctly autocompletes valid format options.
 
 ## [0.5.0]
 ### Added

--- a/cmd/new/new.go
+++ b/cmd/new/new.go
@@ -63,11 +63,7 @@ func CreateCommand() *cobra.Command {
 
 	tmp.Flags().StringVar(&format, "format", "table", "display output in table or json format")
 	err = tmp.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		var formats = []string{"table", "json"}
-		return utils.Find(formats, toComplete), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+		return []string{"table", "json"}, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 	})
 	cobra.CheckErr(err)
 


### PR DESCRIPTION
Prior to this PR, the `--format` flag when calling `pct new` did not autocomplete the options or suggest them.

This PR corrects that bug and ensures that:

1. Attempting to autocomplete without specifying any text after `--format` cycles through the available options
2. Attempting to autocomplete with a partial match for any valid option cycles through all valid options which match
