### PR TITLE
(MAINT) Switch to go install goreleaser on GHA workflows

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -32,7 +32,7 @@ jobs:
         go-version: ${{ env.go_version }}
     - name: Build nix
       run: |
-        go get github.com/goreleaser/goreleaser
+        go install github.com/goreleaser/goreleaser@latest
         ./build.sh
       if: runner.os != 'Windows'
       env:
@@ -40,7 +40,7 @@ jobs:
         HONEYCOMB_DATASET: pct_dev
     - name: Build Windows
       run: |
-        go get github.com/goreleaser/goreleaser
+        go install github.com/goreleaser/goreleaser@latest
         ./build.ps1
       if: runner.os == 'Windows'
       env:


### PR DESCRIPTION
We encountered a dependency issue using `go get` to fetch
`goreleaser` on the PRM workflows. The method we should have been
using anyway was `go install github.com/goreleaser/goreleaser@latest`

This commit updates the `acceptance.yml` workflow to use this
method