### PR TITLE
Genericize PCT install errors

### DIFF
--- a/acceptance/install/install_test.go
+++ b/acceptance/install/install_test.go
@@ -203,7 +203,7 @@ func Test_PctInstall_Errors_When_TemplatePkgNotExist(t *testing.T) {
 	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Assert
-	assert.Contains(t, stdout, fmt.Sprintf("No template package at %v", templatePkgPath))
+	assert.Contains(t, stdout, fmt.Sprintf("No package at %v", templatePkgPath))
 	assert.Equal(t, "exit status 1", stderr)
 	assert.Equal(t, 1, exitCode)
 }
@@ -237,7 +237,7 @@ func Test_PctInstall_Errors_When_InvalidTarProvided(t *testing.T) {
 	stdout, stderr, exitCode := testutils.RunAppCommand(installCmd, "")
 
 	// Assert
-	assert.Contains(t, stdout, fmt.Sprintf("Could not UNTAR template (%v)", templatePkgPath))
+	assert.Contains(t, stdout, fmt.Sprintf("Could not UNTAR package (%v)", templatePkgPath))
 	assert.Equal(t, "exit status 1", stderr)
 	assert.Equal(t, 1, exitCode)
 }
@@ -309,7 +309,7 @@ func Test_PctInstall_ForceSuccessWhenTemplateAlreadyExists(t *testing.T) {
 func removeInstalledTemplate(templatePath string) {
 	_, err := os.Stat(templatePath)
 	if err != nil {
-		panic(fmt.Sprintf("removeInstalledTemplate(): Could not determine if template path (%v) exists: %v", templatePath, err))
+		panic(fmt.Sprintf("removeInstalledTemplate(): Could not determine if Package path (%v) exists: %v", templatePath, err))
 	}
 
 	os.RemoveAll(templatePath)
@@ -420,7 +420,7 @@ func Test_PctInstall_WithGitUri_FailsWithInvalidUri(t *testing.T) {
 	stdout, stderr, exitCode := testutils.RunAppCommand("install --git-uri example.com/invalid-git-uri", "")
 
 	// Assert
-	assert.Contains(t, stdout, "Could not parse template uri")
+	assert.Contains(t, stdout, "Could not parse package uri")
 	assert.Equal(t, "exit status 1", stderr)
 	assert.Equal(t, 1, exitCode)
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -53,7 +53,7 @@ func (p *Installer) Install(templatePkg, targetDir string, force bool) (string, 
 	}
 
 	if _, err := p.AFS.Stat(templatePkg); os.IsNotExist(err) {
-		return "", fmt.Errorf("No template package at %v", templatePkg)
+		return "", fmt.Errorf("No package at %v", templatePkg)
 	}
 
 	// create a temporary Directory to extract the tar.gz to
@@ -63,7 +63,7 @@ func (p *Installer) Install(templatePkg, targetDir string, force bool) (string, 
 		log.Debug().Msgf("Failed to remove temp dir: %v", err)
 	}()
 	if err != nil {
-		return "", fmt.Errorf("Could not create tempdir to gunzip template: %v", err)
+		return "", fmt.Errorf("Could not create tempdir to gunzip package: %v", err)
 	}
 
 	// gunzip the tar.gz to created tempdir
@@ -75,7 +75,7 @@ func (p *Installer) Install(templatePkg, targetDir string, force bool) (string, 
 	// untar the above archive to the temp dir
 	untarPath, err := p.Tar.Untar(tarfile, tempDir)
 	if err != nil {
-		return "", fmt.Errorf("Could not UNTAR template (%v): %v", templatePkg, err)
+		return "", fmt.Errorf("Could not UNTAR package (%v): %v", templatePkg, err)
 	}
 
 	// Process the configuration file and set up namespacedPath and relocate config and content to it
@@ -90,7 +90,7 @@ func (p *Installer) Install(templatePkg, targetDir string, force bool) (string, 
 func (p *Installer) processDownload(templatePkg *string) error {
 	u, err := url.ParseRequestURI(*templatePkg)
 	if err != nil {
-		return fmt.Errorf("Could not parse template url %s: %v", *templatePkg, err)
+		return fmt.Errorf("Could not parse package url %s: %v", *templatePkg, err)
 	}
 	// Create a temporary Directory to download the tar.gz to
 	tempDownloadDir, err := p.AFS.TempDir("", "")
@@ -99,12 +99,12 @@ func (p *Installer) processDownload(templatePkg *string) error {
 		log.Debug().Msgf("Failed to remove temp dir: %v", err)
 	}()
 	if err != nil {
-		return fmt.Errorf("Could not create tempdir to download template: %v", err)
+		return fmt.Errorf("Could not create tempdir to download package: %v", err)
 	}
 	// Download template and assign location to templatePkg
 	*templatePkg, err = p.downloadTemplate(u, tempDownloadDir)
 	if err != nil {
-		return fmt.Errorf("Could not effectively download template: %v", err)
+		return fmt.Errorf("Could not effectively download package: %v", err)
 	}
 	return nil
 }
@@ -113,7 +113,7 @@ func (p *Installer) InstallClone(gitUri, targetDir, tempDir string, force bool) 
 	// Validate git URI
 	_, err := url.ParseRequestURI(gitUri)
 	if err != nil {
-		return "", fmt.Errorf("Could not parse template uri %s: %v", gitUri, err)
+		return "", fmt.Errorf("Could not parse package uri %s: %v", gitUri, err)
 	}
 
 	// Clone git repository to temp folder

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -82,13 +82,13 @@ func TestInstall(t *testing.T) {
 
 	tests := []InstallTest{
 		{
-			name: "if it the file does not exist",
+			name: "if the file does not exist",
 			args: args{
 				templatePath: filepath.Join(templatePath, "good-project.tar.gz"),
 				targetDir:    templatePath,
 			},
 			expected: expected{
-				errorMsg: fmt.Sprintf("No template package at %v", filepath.Join(templatePath, "good-project.tar.gz")),
+				errorMsg: fmt.Sprintf("No package at %v", filepath.Join(templatePath, "good-project.tar.gz")),
 			},
 		},
 		{
@@ -236,7 +236,7 @@ func TestInstall(t *testing.T) {
 				targetDir:    extractionPath,
 			},
 			expected: expected{
-				errorMsg: "Template already installed",
+				errorMsg: "Package already installed",
 			},
 			mockReponses: mockReponses{
 				untar: []mock.UntarResponse{
@@ -256,7 +256,7 @@ func TestInstall(t *testing.T) {
 					},
 				},
 			},
-			mockInstallConfig: mockInstallConfig{ErrResponse: fmt.Errorf("Template already installed")},
+			mockInstallConfig: mockInstallConfig{ErrResponse: fmt.Errorf("Package already installed")},
 			mocks: mocks{
 				dirs: []string{
 					templatePath,
@@ -289,7 +289,7 @@ func TestInstall(t *testing.T) {
 			},
 		},
 		{
-			name: "should download and extract a remote tar.gz to a template folder",
+			name: "should download and extract a remote tar.gz to a package folder",
 			args: args{
 				templatePath: fmt.Sprintf("%s/%s", remoteTemplatPath, "good-project.tar.gz"),
 				targetDir:    extractionPath,
@@ -333,7 +333,7 @@ func TestInstall(t *testing.T) {
 				gitUri: "invalid-uri",
 			},
 			expected: expected{
-				errorMsg: "Could not parse template uri",
+				errorMsg: "Could not parse package uri",
 			},
 		},
 		{


### PR DESCRIPTION
Overview of PR:

- To genericize `pct install` errors, so that error output is more understandable in the `prm` program.
