### PR TITLE
(MAINT) Skip tests in non CI environments

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   go_version: 1.16
+  CI: true
 
 jobs:
   build:

--- a/acceptance/install/install_test.go
+++ b/acceptance/install/install_test.go
@@ -16,6 +16,7 @@ var defaultTemplatePath string
 
 func Test_PctInstall_InstallsTo_DefaultTemplatePath(t *testing.T) {
 	testutils.SkipAcceptanceTest(t)
+	testutils.SkipTestInNonCIEnv(t) // We cannot exec this in a local Dev environment
 	testutils.SetAppName(APP)
 
 	// Setup

--- a/acceptance/testutils/testutils.go
+++ b/acceptance/testutils/testutils.go
@@ -25,6 +25,12 @@ func SkipAcceptanceTest(t *testing.T) {
 	}
 }
 
+func SkipTestInNonCIEnv(t *testing.T) {
+	if _, ci := os.LookupEnv("CI"); !ci {
+		t.Skip("Skipping test execution in non-CI environment")
+	}
+}
+
 // Run Command takes a command to execute and the directory in which to execute the command.
 // if wd is and empty string it will default to the current working directory
 func RunCommand(cmdString string, wd string) (stdout string, stderr string, exitCode int) {

--- a/pkg/mock/gunzip.go
+++ b/pkg/mock/gunzip.go
@@ -32,10 +32,11 @@ func (g *Gunzip) Gunzip(source, target string) (string, error) {
 	// this code extracts a tar.gz, producing a tar witin target
 	// using the mock fs, ensure that this exists
 	// unless we want to test that NOT EXIST condition
+	/* #nosec */
 	if !g.GunzipResponse[g.gunzipCalled].Fail {
 		afs := &afero.Afero{Fs: g.Fs}
 		tar := strings.TrimSuffix(filepath.Join(target, filepath.Base(source)), ".gz")
-		afs.Create(tar) // nolint:errcheck  // #nosec // this result is not used in a secure application
+		afs.Create(tar) // nolint:errcheck  // this result is not used in a secure application
 	}
 
 	path := g.GunzipResponse[g.gunzipCalled].FilePath


### PR DESCRIPTION
There are a small number of tests that we cannot run on a local
dev environment.
    
This PR:
- Adds a function to the testutils package that will
   skip over the test if the env var `CI` is not set
- Excludes the `PctInstall_InstallsTo_DefaultTemplatePath`
   from execution outside of a CI env, as it will interact with
   a local dev template path
- Adds the `CI` env var to the `acceptance.yml` workflow

