### PR TITLE
(MAINT) Remove local directive for docs module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/puppetlabs/pdkgo
 
 go 1.16
 
-replace github.com/puppetlabs/pdkgo/docs/md => ./docs/md
-
 require (
 	github.com/alecthomas/chroma v0.9.4 // indirect
 	github.com/charmbracelet/glamour v0.3.0
@@ -17,7 +15,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.9.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/puppetlabs/pdkgo/docs/md v0.0.0-00010101000000-000000000000
+	github.com/puppetlabs/pdkgo/docs/md v0.0.0-20211222164114-ec8a1116e97a
 	github.com/rs/zerolog v1.26.0
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/puppetlabs/pdkgo/docs/md v0.0.0-20211222164114-ec8a1116e97a h1:uodh4NoBhFzS/AxUm7eo6yNLgOgNAG46PQ1V/nn8jQw=
+github.com/puppetlabs/pdkgo/docs/md v0.0.0-20211222164114-ec8a1116e97a/go.mod h1:ZP68DAFqSxcmtVQ4WNS1uzO5ruFuL0geGIXoznIZx6w=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
In this PR:

- This PR drops the replacement directive from `go.mod` so that we
reference the package correctly on Github.