### PR TITLE
(GH-331) Update Telemetry to report whether run is on CI

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -5,6 +5,7 @@ package telemetry
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"strings"
 
@@ -86,6 +87,11 @@ func Start(ctx context.Context, honeycomb_api_key string, honeycomb_dataset stri
 	AddStringSpanAttribute(span, "uuid", machineUUID)
 	AddStringSpanAttribute(span, "osinfo/os", runtime.GOOS)
 	AddStringSpanAttribute(span, "osinfo/arch", runtime.GOARCH)
+	runningInCi := os.Getenv("CI")
+	if runningInCi == "" {
+		runningInCi = "false"
+	}
+	AddStringSpanAttribute(span, "ci", strings.ToLower(runningInCi))
 
 	return ctx, tp, span
 }


### PR DESCRIPTION
Added an additional attribute to the gathered Honeycomb telemetry, reporting whether or not the code has been run as part of our CI or not.

Link to function used to retrieve CI status:
https://zetcode.com/golang/env/#:~:text=or%20viper%20libraries.-,Go%20os.Getenv,-The%20Getenv%20retrieves

<img width="1131" alt="Screen Shot 2022-01-11 at 11 38 38 AM" src="https://user-images.githubusercontent.com/21069923/148936131-9edf5725-0b55-46e4-862f-1a542e3e449d.png">

