### PR TITLE
(MAINT) Handle default for GOAMD64 builds

### DIFF
--- a/acceptance/testutils/testutils.go
+++ b/acceptance/testutils/testutils.go
@@ -60,7 +60,12 @@ func RunAppCommand(cmdString string, wd string) (stdout string, stderr string, e
 		postfix = ".exe"
 	}
 
-	appPath := fmt.Sprintf("../../dist/%s_%s_%s/%s%s", app, runtime.GOOS, runtime.GOARCH, app, postfix)
+	goArch := runtime.GOARCH
+	if goArch == "amd64" {
+		goArch = fmt.Sprintf("%s_v1", runtime.GOARCH)
+	}
+
+	appPath := fmt.Sprintf("../../dist/%s_%s_%s/%s%s", app, runtime.GOOS, goArch, app, postfix)
 	absPath, err := filepath.Abs(appPath)
 
 	if err != nil {

--- a/build.ps1
+++ b/build.ps1
@@ -14,6 +14,12 @@ $platform = go env GOHOSTOS
 $binPath = Join-Path $PSScriptRoot "dist" "pct_${platform}_${arch}"
 $binPath2 = Join-Path $PSScriptRoot "dist" "notel_pct_${platform}_${arch}"
 
+$amd64 = go env GOAMD64
+if ($amd64) {
+	$binPath = "${binPath}_${amd64}"
+	$binPath2 = "${binPath2}_${amd64}"
+}
+
 switch ($Target) {
   'build' {
     # Set goreleaser to build for current platform only
@@ -26,6 +32,7 @@ switch ($Target) {
     }
     goreleaser build --snapshot --rm-dist --single-target
     git clone -b main --depth 1 --single-branch https://github.com/puppetlabs/baker-round (Join-Path $binPath "templates")
+		Get-ChildItem -Path (Join-Path $binPath "templates")
     Copy-Item (Join-Path $binPath "templates") -Destination (Join-Path $binPath2 "templates") -Recurse
   }
   'quick' {

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,12 @@ platform=$(go env GOHOSTOS)
 binPath="$(pwd)/dist/pct_${platform}_${arch}"
 binPath2="$(pwd)/dist/notel_pct_${platform}_${arch}"
 
+amd64=$(go env GOAMD64)
+if [[ ! -z "${amd64+z}" ]]; then
+	binPath="${binPath}_${amd64}"
+	binPath2="${binPath2}_${amd64}"
+fi
+
 if [ "$target" == "build" ]; then
   # Set goreleaser to build for current platform only
   if [ -z "${HONEYCOMB_API_KEY}" ]; then


### PR DESCRIPTION
As of go 1.18, the GOAMD64 has been introduced to represent the different microarchitecture levels to compile for when GOARCH is amd64.

It would appear that GOAMD64 is not available in the runtime package, so in this PR we are making an assumption that we will be building for the default of v1. This is currently true for goreleaser config in PRM and PCT.

<!--
Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/pdkgo/blob/main/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/pdkgo/blob/main/CODE_OF_CONDUCT.md

Submitting a Pull Request:

- Create a fork of this repo in Github
- Create a new branch `git checkout -b my-branch-name`
- Make you change, add tests, and ensure tests pass
- Do not reformat existing code, it makes it hard to see what has changed. Leave the formatting to us.
- Make sure your commit messages are in the proper format. If the commit addresses an issue filed in the project, start the first line of the commit with the prefix `GH-` and the issue number in parentheses `(GH-111)`. Then leave a detailed explanation of your change, so a person in the future can understand what your work does.
- Update the `Unreleased` section in the CHANGELOG.md with your change

THANKS!
-->
